### PR TITLE
Calling exec() replaces the currently running process, causing rake/rspe...

### DIFF
--- a/rails/spec/html_compare_helper.rb
+++ b/rails/spec/html_compare_helper.rb
@@ -61,7 +61,7 @@ module HTMLCompareHelper
       # Write it out to a file
       output("old.#{format}", o, path)
       output("new.#{format}", n, path)
-      exec("#{diff_path} old.#{format} new.#{format}")
+      system("#{diff_path} old.#{format} new.#{format}")
       raise "Don't match. Writing to file old.#{format} and new.#{format}"
     end
   end


### PR DESCRIPTION
...c to bail. Using system() instead.
