### PR TITLE
Revert "Display 0% correctly"

### DIFF
--- a/website/pretty.inc
+++ b/website/pretty.inc
@@ -568,7 +568,7 @@ function pretty_user_name($db, $name, $text = null) {
 }
 
 function pretty_distance_to_agreement($distance) {
-    if($distance) {
+    if(!is_null($distance)) {
       $agreement = (1.0 - (float)($distance)) * 100.0;
     }else{
       $agreement = 0;


### PR DESCRIPTION
Fixes #231.

For easy verification, [this](http://localhost:8080/mp.php?mpn=Sarah_Hanson-Young&mpc=Senate&house=senate&display=allfriends) is a mp with a 100% friend, [this](http://localhost:8080/mp.php?mpn=Tony_Zappia&mpc=Makin&house=representatives&display=allfriends) is a mp with a 0% friend (at least in my dataset).
