### PR TITLE
Show provisional status of policy when editing. Fixes #235

### DIFF
--- a/rails/app/models/policy.rb
+++ b/rails/app/models/policy.rb
@@ -28,6 +28,10 @@ class Policy < ActiveRecord::Base
     votes_count - edited_motions_count
   end
 
+  def provisional?
+    status == "provisional"
+  end
+
   def status
     case private
     when 0

--- a/rails/app/views/policies/_edit_policy.html.haml
+++ b/rails/app/views/policies/_edit_policy.html.haml
@@ -26,7 +26,7 @@
     should be able to agree which way the policy votes in each
     division</em>.)
   %p
-    %input#provisional{:name => "provisional", :type => "checkbox", :value => "provisional"}/
+    %input#provisional{:name => "provisional", :type => "checkbox", :value => "provisional", :checked => @policy.provisional?}/
     %label.ptitle{:for => "provisional"} Provisional policy
     ('provisional' means the
     policy is not yet complete or consistent enough to display on MP


### PR DESCRIPTION
This will have a small merge conflict because I've added the same method to the policy class that I added in the other PR.
