### PR TITLE
Motion text truncation

### DIFF
--- a/lib/data_loader/division_xml.rb
+++ b/lib/data_loader/division_xml.rb
@@ -1,5 +1,7 @@
 module DataLoader
   class DivisionXML
+    MAXIMUM_MOTION_TEXT_SIZE = 15000
+
     def initialize(division_xml, house)
       @division_xml = division_xml
       @house = House.australian_to_uk(house)
@@ -51,7 +53,7 @@ module DataLoader
       text = pwmotiontext.empty? ? previous_speeches_motion_text : pwmotiontext
       # Truncate really long motion text at the same size as formatted_motion_text
       Rails.logger.warn "Truncating very long motion text for division: #{house} #{date} #{number}" if text.size > 15000
-      encode_html_entities(text.truncate 15000)
+      encode_html_entities(text.truncate MAXIMUM_MOTION_TEXT_SIZE)
     end
 
     def clock_time
@@ -151,7 +153,7 @@ module DataLoader
       output_text = ''
 
       previous_speeches.map { |s| speech_text s }.each do |speech|
-        if (output_text + speech).size > (15000 - truncation_text.size)
+        if (output_text + speech).size > (MAXIMUM_MOTION_TEXT_SIZE - truncation_text.size)
           output_text += truncation_text
           break
         else


### PR DESCRIPTION
This is a work in progress to fix #305. I don't want it merged yet as I want to get Ruby and PHP creating the exact same output to ensure the Ruby importer is working. That means this can only happen after I've done that.

There's also more work TODO: remove the `.truncate` and do the same thing for pwmotiontext-generated motion text.
