### PR TITLE
Remove 'house' column from vote tables on member pages. Fixes #382

### DIFF
--- a/app/views/members/_votes.html.haml
+++ b/app/views/members/_votes.html.haml
@@ -1,6 +1,5 @@
 %thead
   %tr.headings
-    %th House
     %th Date
     %th Subject
     %th= member.name
@@ -13,8 +12,6 @@
   - else
     - divisions.each do |division|
       %tr
-        %td{:class => division.house}
-          = division.australian_house.capitalize
         %td= formatted_date(division.date, true)
         %td= link_to truncate(division.name, length: 180), division_with_member_path(division, member)
         %td= division.vote_for(member)

--- a/spec/fixtures/static_pages/mp.php?mpn=Barnaby_Joyce&mpc=New_England&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Barnaby_Joyce&mpc=New_England&house=representatives.html
@@ -123,7 +123,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=representatives&amp;mpc=Ne
 <table class="table table-striped">
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Barnaby Joyce</th>
@@ -139,7 +138,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=representatives&amp;mpc=Ne
 
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Barnaby Joyce</th>

--- a/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&display=everyvote.html
@@ -58,7 +58,6 @@ Senator Christine Milne
 <table class="table table-striped">
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Christine Milne</th>
@@ -68,9 +67,6 @@ Senator Christine Milne
 </thead>
 <tbody>
 <tr>
-<td class="lords">
-Senate
-</td>
 <td>14&nbsp;Mar&nbsp;2013</td>
 <td><a href="/division.php?date=2013-03-14&amp;house=senate&amp;mpc=Tasmania&amp;mpn=Christine_Milne&amp;number=1">Motions — Renewable Energy Certificates</a></td>
 <td>no</td>
@@ -80,9 +76,6 @@ loyal
 </td>
 </tr>
 <tr>
-<td class="lords">
-Senate
-</td>
 <td>30&nbsp;Dec&nbsp;2009</td>
 <td><a href="/division.php?date=2009-12-30&amp;house=senate&amp;mpc=Tasmania&amp;mpn=Christine_Milne&amp;number=8">Proceedural ban of flatulence during divisions</a></td>
 <td>aye</td>
@@ -92,9 +85,6 @@ loyal
 </td>
 </tr>
 <tr>
-<td class="lords">
-Senate
-</td>
 <td>30&nbsp;Nov&nbsp;2009</td>
 <td><a href="/division.php?date=2009-11-30&amp;house=senate&amp;mpc=Tasmania&amp;mpn=Christine_Milne&amp;number=8">Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading</a></td>
 <td>no</td>
@@ -104,9 +94,6 @@ loyal
 </td>
 </tr>
 <tr>
-<td class="lords">
-Senate
-</td>
 <td>25&nbsp;Nov&nbsp;2009</td>
 <td><a href="/division.php?date=2009-11-25&amp;house=senate&amp;mpc=Tasmania&amp;mpn=Christine_Milne&amp;number=8">Carbon Pollution Reduction Scheme Legislation</a></td>
 <td>no</td>

--- a/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate.html
@@ -117,7 +117,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=senate&amp;mpc=Tasmania&am
 <table class="table table-striped">
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Christine Milne</th>

--- a/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate_2.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate_2.html
@@ -121,7 +121,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=senate&amp;mpc=Tasmania&am
 <table class="table table-striped">
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Christine Milne</th>

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=everyvote.html
@@ -58,7 +58,6 @@ Kevin Rudd MP
 <table class="table table-striped">
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Kevin Rudd</th>
@@ -68,9 +67,6 @@ Kevin Rudd MP
 </thead>
 <tbody>
 <tr>
-<td class="commons">
-Representatives
-</td>
 <td>14&nbsp;Mar&nbsp;2013</td>
 <td><a href="/division.php?date=2013-03-14&amp;house=representatives&amp;mpc=Griffith&amp;mpn=Kevin_Rudd&amp;number=1">test</a></td>
 <td>no</td>
@@ -80,9 +76,6 @@ loyal
 </td>
 </tr>
 <tr>
-<td class="commons">
-Representatives
-</td>
 <td>6&nbsp;Dec&nbsp;2006</td>
 <td><a href="/division.php?date=2006-12-06&amp;house=representatives&amp;mpc=Griffith&amp;mpn=Kevin_Rudd&amp;number=3">Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 — Consideration in Detail</a></td>
 <td>aye</td>

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives.html
@@ -120,7 +120,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=representatives&amp;mpc=Gr
 <table class="table table-striped">
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Kevin Rudd</th>
@@ -130,9 +129,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=representatives&amp;mpc=Gr
 </thead>
 <tbody>
 <tr>
-<td class="commons">
-Representatives
-</td>
 <td>6&nbsp;Dec&nbsp;2006</td>
 <td><a href="/division.php?date=2006-12-06&amp;house=representatives&amp;mpc=Griffith&amp;mpn=Kevin_Rudd&amp;number=3">Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 — Consideration in Detail</a></td>
 <td>aye</td>

--- a/spec/fixtures/static_pages/mp.php?mpn=Roger_Price&mpc=Chifley&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Roger_Price&mpc=Chifley&house=representatives.html
@@ -118,7 +118,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=representatives&amp;mpc=Ch
 <table class="table table-striped">
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Roger Price</th>
@@ -128,9 +127,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=representatives&amp;mpc=Ch
 </thead>
 <tbody>
 <tr>
-<td class="commons">
-Representatives
-</td>
 <td>6&nbsp;Dec&nbsp;2006</td>
 <td><a href="/division.php?date=2006-12-06&amp;house=representatives&amp;mpc=Chifley&amp;mpn=Roger_Price&amp;number=3">Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 — Consideration in Detail</a></td>
 <td>aye</td>

--- a/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&display=everyvote.html
@@ -58,7 +58,6 @@ Tony Abbott MP
 <table class="table table-striped">
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Tony Abbott</th>
@@ -68,9 +67,6 @@ Tony Abbott MP
 </thead>
 <tbody>
 <tr>
-<td class="commons">
-Representatives
-</td>
 <td>14&nbsp;Mar&nbsp;2013</td>
 <td><a href="/division.php?date=2013-03-14&amp;house=representatives&amp;mpc=Warringah&amp;mpn=Tony_Abbott&amp;number=1">test</a></td>
 <td>absent</td>
@@ -80,9 +76,6 @@ absent
 </td>
 </tr>
 <tr>
-<td class="commons">
-Representatives
-</td>
 <td>6&nbsp;Dec&nbsp;2006</td>
 <td><a href="/division.php?date=2006-12-06&amp;house=representatives&amp;mpc=Warringah&amp;mpn=Tony_Abbott&amp;number=3">Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 — Consideration in Detail</a></td>
 <td>aye</td>

--- a/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives.html
@@ -119,7 +119,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=representatives&amp;mpc=Wa
 <table class="table table-striped">
 <thead>
 <tr class="headings">
-<th>House</th>
 <th>Date</th>
 <th>Subject</th>
 <th>Tony Abbott</th>
@@ -129,9 +128,6 @@ See also <a href="/mp.php?display=everyvote&amp;house=representatives&amp;mpc=Wa
 </thead>
 <tbody>
 <tr>
-<td class="commons">
-Representatives
-</td>
 <td>6&nbsp;Dec&nbsp;2006</td>
 <td><a href="/division.php?date=2006-12-06&amp;house=representatives&amp;mpc=Warringah&amp;mpn=Tony_Abbott&amp;number=3">Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 — Consideration in Detail</a></td>
 <td>aye</td>


### PR DESCRIPTION
I just removed it completely. What do you think @equivalentideas? Do we need it on the all votes page?
