### PR TITLE
add date and house to division in policy vote details

### DIFF
--- a/app/views/policies/_detailed_votes.html.haml
+++ b/app/views/policies/_detailed_votes.html.haml
@@ -5,11 +5,13 @@
     - if member
       %h4
         = link_to division_with_member_path(division, member) do
-          #{division.name} - #{formatted_date(division.date)} - Division No. #{division.number}
+          %small.pre-title= division_date_and_time(division) + ", " + division.australian_house_name
+          #{division.name} - Division No. #{division.number}
     - else
       %h4
         = link_to division_with_policy_path(division, dmp: policy.id) do
-          #{division.name} - #{formatted_date(division.date)} - Division No. #{division.number}
+          %small.pre-title= division_date_and_time(division) + ", " + division.australian_house_name
+          #{division.name} - Division No. #{division.number}
     .row
       .col-md-6
         %p

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&dmp=1&display=motions.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&dmp=1&display=motions.html
@@ -87,7 +87,8 @@ Someone who believes that
 would cast votes described by the policy.
 </p>
 <h4>
-<a href="/division.php?date=2013-03-14&amp;house=representatives&amp;mpc=Griffith&amp;mpn=Kevin_Rudd&amp;number=1">test - 14 Mar 2013 - Division No. 1
+<a href="/division.php?date=2013-03-14&amp;house=representatives&amp;mpc=Griffith&amp;mpn=Kevin_Rudd&amp;number=1"><small class="pre-title">14 Mar 2013 at 10:56, Representatives</small>
+test - Division No. 1
 </a></h4>
 <div class="row">
 <div class="col-md-6">

--- a/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&dmp=1&display=motions.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&dmp=1&display=motions.html
@@ -87,7 +87,8 @@ Someone who believes that
 would cast votes described by the policy.
 </p>
 <h4>
-<a href="/division.php?date=2013-03-14&amp;house=representatives&amp;mpc=Warringah&amp;mpn=Tony_Abbott&amp;number=1">test - 14 Mar 2013 - Division No. 1
+<a href="/division.php?date=2013-03-14&amp;house=representatives&amp;mpc=Warringah&amp;mpn=Tony_Abbott&amp;number=1"><small class="pre-title">14 Mar 2013 at 10:56, Representatives</small>
+test - Division No. 1
 </a></h4>
 <div class="row">
 <div class="col-md-6">

--- a/spec/fixtures/static_pages/policy.php?id=1&display=motions.html
+++ b/spec/fixtures/static_pages/policy.php?id=1&display=motions.html
@@ -57,7 +57,8 @@ Marriage equality
 </div>
 
 <h4>
-<a href="/division.php?date=2013-03-14&amp;dmp=1&amp;house=representatives&amp;number=1">test - 14 Mar 2013 - Division No. 1
+<a href="/division.php?date=2013-03-14&amp;dmp=1&amp;house=representatives&amp;number=1"><small class="pre-title">14 Mar 2013 at 10:56, Representatives</small>
+test - Division No. 1
 </a></h4>
 <div class="row">
 <div class="col-md-6">

--- a/spec/fixtures/static_pages/policy.php?id=2&display=motions.html
+++ b/spec/fixtures/static_pages/policy.php?id=2&display=motions.html
@@ -57,7 +57,8 @@ Offshore processing
 </div>
 
 <h4>
-<a href="/division.php?date=2013-03-14&amp;dmp=2&amp;house=senate&amp;number=1">Motions — Renewable Energy Certificates - 14 Mar 2013 - Division No. 1
+<a href="/division.php?date=2013-03-14&amp;dmp=2&amp;house=senate&amp;number=1"><small class="pre-title">14 Mar 2013, Senate</small>
+Motions — Renewable Energy Certificates - Division No. 1
 </a></h4>
 <div class="row">
 <div class="col-md-6">
@@ -104,7 +105,8 @@ Totals
 </div>
 </div>
 <h4>
-<a href="/division.php?date=2006-12-06&amp;dmp=2&amp;house=representatives&amp;number=3">Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 — Consideration in Detail - 6 Dec 2006 - Division No. 3
+<a href="/division.php?date=2006-12-06&amp;dmp=2&amp;house=representatives&amp;number=3"><small class="pre-title">6 Dec 2006 at 19:29, Representatives</small>
+Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 — Consideration in Detail - Division No. 3
 </a></h4>
 <div class="row">
 <div class="col-md-6">


### PR DESCRIPTION
fixes #415 

This effects the division title on the policy's vote details and the member's policy/display="motion"
