### PR TITLE
broken helper for division outcome with score

### DIFF
--- a/app/helpers/divisions_helper.rb
+++ b/app/helpers/divisions_helper.rb
@@ -92,23 +92,15 @@ module DivisionsHelper
   end
 
   def division_outcome_with_score(division)
-    if division.tied?
-      division_outcome(division)
-    else
+    result = division_outcome(division) + " "
+    result += content_tag(:span, :class => "division-outcome-score") do
       if division.passed?
-        division_outcome(division)
+        text = division.aye_votes_including_tells.to_s + " – " + division.no_votes_including_tells.to_s
       else
-        division_outcome(division)
+        text = division.no_votes_including_tells.to_s + " – " + division.aye_votes_including_tells.to_s
       end
     end
-
-    content_tag :span, :class => "division-outcome-score" do
-      if division.passed?
-        text = division.aye_votes_including_tells + " – " + division.no_votes_including_tells
-      else
-        text = division.no_votes_including_tells + " – " + division.aye_votes_including_tells
-      end
-    end
+    result.html_safe
   end
 
   def member_voted_with(member, division)


### PR DESCRIPTION
Could @mlandauer or @henare have a look and fix this ruby up. The idea is to make a helper that produces the outcome of the division with the "score".

> Passed 54 - 40
> Not passed 84 - 7
