### PR TITLE
Simplify divisions#index intro copy

### DIFF
--- a/app/views/divisions/index.html.haml
+++ b/app/views/divisions/index.html.haml
@@ -23,7 +23,7 @@
 = render "divisions_chooser", rdisplay: @rdisplay, rdisplay2: @rdisplay2, house: @house, parties: @parties
 
 %p.lead
-  In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. #{link_to "Learn more...", help_path(anchor: "jargon")}
+  In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. #{link_to "Learn more...", help_path(anchor: "jargon")}
 
 - if @rdisplay2 == "rebels"
   %p

--- a/spec/fixtures/static_pages/divisions.php.html
+++ b/spec/fixtures/static_pages/divisions.php.html
@@ -71,7 +71,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?house=representatives&sort=rebellions.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?house=representatives&sort=subject.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?house=representatives&sort=turnout.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?house=representatives.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?house=senate&sort=rebellions.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?house=senate&sort=subject.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?house=senate&sort=turnout.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?house=senate.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Greens_party&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Greens_party&house=senate&sort=rebellions.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Greens_party&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Greens_party&house=senate&sort=subject.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Greens_party&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Greens_party&house=senate&sort=turnout.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Greens_party&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Greens_party&house=senate.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Labor%20Party_party&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Labor%20Party_party&house=representatives&sort=rebellions.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Labor%20Party_party&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Labor%20Party_party&house=representatives&sort=subject.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Labor%20Party_party&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Labor%20Party_party&house=representatives&sort=turnout.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Labor%20Party_party&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Australian%20Labor%20Party_party&house=representatives.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Liberal%20Party_party&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Liberal%20Party_party&house=representatives&sort=rebellions.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Liberal%20Party_party&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Liberal%20Party_party&house=representatives&sort=subject.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Liberal%20Party_party&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Liberal%20Party_party&house=representatives&sort=turnout.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=Liberal%20Party_party&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=Liberal%20Party_party&house=representatives.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=representatives&sort=rebellions.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=representatives&sort=subject.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=representatives&sort=turnout.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=representatives.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=senate&sort=rebellions.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=senate&sort=subject.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=senate&sort=turnout.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&house=senate.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&sort=rebellions.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&sort=subject.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels&sort=turnout.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay2=rebels.html
@@ -71,7 +71,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=rebellions.html
@@ -79,7 +79,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2004&amp;sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=subject.html
@@ -79,7 +79,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2004&amp;sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=turnout.html
@@ -79,7 +79,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2004&amp;sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives.html
@@ -77,7 +77,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2004" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=senate&sort=rebellions.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2004&amp;sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=senate&sort=subject.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2004&amp;sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=senate&sort=turnout.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2004&amp;sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=senate.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2004" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=representatives&sort=rebellions.html
@@ -79,7 +79,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=representatives&sort=subject.html
@@ -79,7 +79,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=representatives&sort=turnout.html
@@ -79,7 +79,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=representatives.html
@@ -77,7 +77,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=senate&sort=rebellions.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=senate&sort=subject.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=senate&sort=turnout.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&house=senate.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&sort=rebellions.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&sort=subject.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels&sort=turnout.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&rdisplay2=rebels.html
@@ -71,7 +71,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=rebellions.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=2004&amp;sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=subject.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=2004&amp;sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=turnout.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=2004&amp;sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004.html
@@ -71,7 +71,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=2004" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=representatives&sort=rebellions.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2007&amp;sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=representatives&sort=subject.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2007&amp;sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=representatives&sort=turnout.html
@@ -75,7 +75,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2007&amp;sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=representatives.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2007" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=rebellions.html
@@ -81,7 +81,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2007&amp;sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=subject.html
@@ -81,7 +81,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2007&amp;sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=turnout.html
@@ -81,7 +81,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2007&amp;sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate.html
@@ -79,7 +79,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2007" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=Australian%20Labor%20Party_party&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=Australian%20Labor%20Party_party&house=representatives.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=2007" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=representatives&sort=rebellions.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=representatives&sort=subject.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=representatives&sort=turnout.html
@@ -75,7 +75,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=representatives.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=senate&sort=rebellions.html
@@ -81,7 +81,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=senate&sort=subject.html
@@ -81,7 +81,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=senate&sort=turnout.html
@@ -81,7 +81,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&house=senate.html
@@ -79,7 +79,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&sort=rebellions.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&sort=subject.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels&sort=turnout.html
@@ -73,7 +73,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&rdisplay2=rebels.html
@@ -71,7 +71,7 @@ Rebellions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=rebellions.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=2007&amp;sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=subject.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=2007&amp;sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=turnout.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=2007&amp;sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007.html
@@ -71,7 +71,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=2007" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=rebellions.html
@@ -79,7 +79,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=all&amp;sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=subject.html
@@ -79,7 +79,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=all&amp;sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=turnout.html
@@ -79,7 +79,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=all&amp;sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives.html
@@ -77,7 +77,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=all" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=rebellions.html
@@ -81,7 +81,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=all&amp;sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=subject.html
@@ -81,7 +81,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=all&amp;sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=turnout.html
@@ -81,7 +81,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=all&amp;sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate.html
@@ -79,7 +79,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-default" href="/divisions.php?rdisplay=all" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=representatives&sort=rebellions.html
@@ -79,7 +79,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=representatives&sort=subject.html
@@ -79,7 +79,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=representatives&sort=turnout.html
@@ -79,7 +79,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=representatives.html
@@ -77,7 +77,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=senate&sort=rebellions.html
@@ -81,7 +81,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=senate&sort=subject.html
@@ -81,7 +81,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=senate&sort=turnout.html
@@ -81,7 +81,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&house=senate.html
@@ -79,7 +79,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&sort=rebellions.html
@@ -73,7 +73,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&sort=subject.html
@@ -73,7 +73,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels&sort=turnout.html
@@ -73,7 +73,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&rdisplay2=rebels.html
@@ -71,7 +71,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <p>
 This is a table showing only the divisions where there were at

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=rebellions.html
@@ -73,7 +73,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=all&amp;sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=subject.html
@@ -73,7 +73,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=all&amp;sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=turnout.html
@@ -73,7 +73,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=all&amp;sort=turnout" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all.html
@@ -71,7 +71,7 @@ All divisions on record
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?rdisplay=all" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?sort=rebellions.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?sort=rebellions" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?sort=subject.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?sort=subject" title="All divisions">Both houses</a>

--- a/spec/fixtures/static_pages/divisions.php?sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?sort=turnout.html
@@ -73,7 +73,7 @@ Divisions
 </form>
 
 <p class="lead">
-In the Parliament of Australia votes are counted in <em>divisions</em>. Through these votes, elected members shape legislation and enact Government policy. <a href="/faq.php#jargon">Learn more...</a>
+In the Australian Parliament a vote is called a <em>division</em>. Through these votes, elected members shape legislation that affects us all. <a href="/faq.php#jargon">Learn more...</a>
 </p>
 <nav class="btn-group">
 <a class="btn btn-sm btn-primary" href="/divisions.php?sort=turnout" title="All divisions">Both houses</a>


### PR DESCRIPTION
Changes the introduction copy on the divisions#index from:

> A 'division' is parliamentary terminology for a 'vote' (read more...). This page shows divisions in the Australian parliament. Make sure you read the explanation about rebellions, as they may not be what you expect. 

to 

> In the Parliament of Australia votes are counted in divisions. Through these votes, elected members shape legislation and enact Government policy. Learn more...

The explanation for Rebellions is linked 'just-in-time' at the top of the rebellions column so doesn't need to be in the intro.
