### PR TITLE
Simplifies /people intro

### DIFF
--- a/app/views/members/index.html.haml
+++ b/app/views/members/index.html.haml
@@ -10,7 +10,7 @@
 .page-header
   %h1
     = yield :title
-    %small in the Federal Parliament
+    %small in the Australian Parliament
 
 .list-filters.clearfix
   %nav.btn-group

--- a/spec/fixtures/static_pages/mps.php?house=representatives&sort=attendance.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives&sort=attendance.html
@@ -55,7 +55,7 @@ Representatives
 Current
 Representatives
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">

--- a/spec/fixtures/static_pages/mps.php?house=representatives&sort=constituency.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives&sort=constituency.html
@@ -55,7 +55,7 @@ Representatives
 Current
 Representatives
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">

--- a/spec/fixtures/static_pages/mps.php?house=representatives&sort=party.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives&sort=party.html
@@ -55,7 +55,7 @@ Representatives
 Current
 Representatives
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">

--- a/spec/fixtures/static_pages/mps.php?house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives&sort=rebellions.html
@@ -57,7 +57,7 @@ Rebel,
 Current
 Representatives
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">

--- a/spec/fixtures/static_pages/mps.php?house=representatives.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives.html
@@ -55,7 +55,7 @@ Representatives
 Current
 Representatives
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">

--- a/spec/fixtures/static_pages/mps.php?house=senate&sort=attendance.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate&sort=attendance.html
@@ -55,7 +55,7 @@ Senators
 Current
 Senators
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">

--- a/spec/fixtures/static_pages/mps.php?house=senate&sort=constituency.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate&sort=constituency.html
@@ -55,7 +55,7 @@ Senators
 Current
 Senators
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">

--- a/spec/fixtures/static_pages/mps.php?house=senate&sort=party.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate&sort=party.html
@@ -55,7 +55,7 @@ Senators
 Current
 Senators
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">

--- a/spec/fixtures/static_pages/mps.php?house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate&sort=rebellions.html
@@ -57,7 +57,7 @@ Rebel,
 Current
 Senators
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">

--- a/spec/fixtures/static_pages/mps.php?house=senate.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate.html
@@ -55,7 +55,7 @@ Senators
 Current
 Senators
 
-<small>in the Federal Parliament</small>
+<small>in the Australian Parliament</small>
 </h1>
 </div>
 <div class="list-filters clearfix">


### PR DESCRIPTION
Makes the /people intro just:

> Current Members of Australia’s Federal Parliament.

The indication of house is in the title and button-group. The links to helper text is in the table.

closes #479 
