### PR TITLE
Namespace the dumped old/new.xml fixture files that are created on spec failure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,5 @@ php/website/google*
 .bundle
 .vagrant
 
-old.xml
-new.xml
+*.old.xml
+*.new.xml

--- a/spec/html_compare_helper.rb
+++ b/spec/html_compare_helper.rb
@@ -80,10 +80,13 @@ module HTMLCompareHelper
       File.open("spec/fixtures/static_pages#{path}#{suffix}.html", "w") do |f|
         f.write new_text
       end
-      output("old.#{format}", o, path)
-      output("new.#{format}", n, path)
-      system("diff old.#{format} new.#{format}")
-      raise "Don't match. Writing to file old.#{format} and new.#{format}"
+      dump_prefix = "#{path}#{suffix}".gsub(/[^\w]/, '_').squeeze("_").sub(/\A_/, '') # /foo/bar.baz?q=1 => foo_bar_baz_q_1
+      old = "#{dump_prefix}.old.#{format}"
+      new = "#{dump_prefix}.new.#{format}"
+      output(old, o, path)
+      output(new, n, path)
+      system('diff', old, new)
+      raise "Don't match. Writing to file #{old} and #{new}"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,8 +32,9 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
-
-    FileUtils.rm_f %w(old.html old.xml new.html new.xml)
+    %w(old.html old.xml new.html new.xml).each do |fn|
+      FileUtils.rm_f Dir["*.#{fn}"]
+    end
   end
 
   # If true, the base class of anonymous controllers will be inferred


### PR DESCRIPTION
Every integration spec failure dumps out a pair of `old.xml` and `new.xml` files. This is fine when there's only one failure, but is not useful when multiple things fail; each failure overwrites the last's files.

This namespaces the files (eg. `policies_edit_2.old.xml`), and updates the ignores and pre-test `rm` that's run on the files from the previous round.
