### PR TITLE
Re-enabled CSRF protection for Policies and Divisions.

### DIFF
--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -1,7 +1,4 @@
 class DivisionsController < ApplicationController
-  # TODO: Reenable CSRF protection
-  skip_before_action :verify_authenticity_token
-
   before_action :authenticate_user!, only: [:edit, :update, :add_policy_vote]
 
   def index_redirect

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -1,7 +1,4 @@
 class PoliciesController < ApplicationController
-  # TODO: Reenable CSRF protection
-  skip_before_action :verify_authenticity_token
-
   before_action :authenticate_user!, except: [:index, :show, :detail, :full]
 
   def index
@@ -62,6 +59,7 @@ class PoliciesController < ApplicationController
   end
 
   def new
+    @policy = Policy.new
   end
 
   def create

--- a/app/views/divisions/edit.html.haml
+++ b/app/views/divisions/edit.html.haml
@@ -26,7 +26,7 @@
     Read the #{link_to "debate leading up to the vote", @division.oa_debate_url, target: '_blank'}.
 .row
   .col-md-8
-    %form{:action => division_path2(@division), :method => "post"}
+    = form_for @division, url: division_path2(@division), method: :post do |f|
       .form-group
         -# TODO Add for to labels
         %label Division title:

--- a/app/views/policies/new.html.haml
+++ b/app/views/policies/new.html.haml
@@ -3,7 +3,7 @@
 .page-header
   %h1= yield :title
 
-- if @policy
+- if @policy.errors.any?
   .error
     %h2 Creating a new policy not complete, please try again
     %p Please name your policy, and give a definition.
@@ -53,7 +53,7 @@
       or you can see how it should be broken down, discuss it with others
       and fix it.
 
-%form{:action => policies_path, :method => "post"}
+= form_for @policy do |f|
   .form-group
     %label If you are for
     %input.form-control{:maxlength => "50", :name => "name", :size => "40", :type => "text", :value => (params[:name] || ''), :placeholder => "equal treatment of same-sex couples"}/

--- a/spec/fixtures/static_pages/account/wiki.php?type=motion&date=2009-11-25&number=8&house=senate&rr=%2Fdivision.php%3Fdate%3D2009-11-25%26number%3D8%26house%3Dsenate.html
+++ b/spec/fixtures/static_pages/account/wiki.php?type=motion&date=2009-11-25&number=8&house=senate&rr=%2Fdivision.php%3Fdate%3D2009-11-25%26number%3D8%26house%3Dsenate.html
@@ -86,8 +86,7 @@ Read the <a href="http://www.openaustralia.org/senate/?id=2009-11-25.76.2" targe
 </p>
 <div class="row">
 <div class="col-md-8">
-<form action="/divisions/senate/2009-11-25/8" method="post">
-<div class="form-group">
+<form accept-charset="UTF-8" action="/divisions/senate/2009-11-25/8" class="edit_division" id="edit_division_2037" method="post"><div style="display:none"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group">
 <label>Division title:</label>
 <input class="form-control" maxlength="250" name="newtitle" size="50" type="text" value="Carbon Pollution Reduction Scheme Legislation" />
 </div>
@@ -98,6 +97,7 @@ Read the <a href="http://www.openaustralia.org/senate/?id=2009-11-25.76.2" targe
 <input accesskey="S" class="btn btn-primary" name="submit" type="submit" value="Save" />
 <input class="btn btn-default" name="submit" type="submit" value="Cancel" />
 </form>
+
 <p>
 <a href="/divisions/senate/2009-11-25/8/history">View change history</a>
 </p>

--- a/spec/fixtures/static_pages/account/wiki.php?type=motion&date=2013-03-14&number=1&house=representatives&rr=%2Fdivision.php%3Fdate%3D2013-03-14%26number%3D1%26house%3Drepresentatives.html
+++ b/spec/fixtures/static_pages/account/wiki.php?type=motion&date=2013-03-14&number=1&house=representatives&rr=%2Fdivision.php%3Fdate%3D2013-03-14%26number%3D1%26house%3Drepresentatives.html
@@ -86,8 +86,7 @@ Read the <a href="http://www.openaustralia.org/debates/?id=2013-03-14.17.1" targ
 </p>
 <div class="row">
 <div class="col-md-8">
-<form action="/divisions/representatives/2013-03-14/1" method="post">
-<div class="form-group">
+<form accept-charset="UTF-8" action="/divisions/representatives/2013-03-14/1" class="edit_division" id="edit_division_1" method="post"><div style="display:none"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group">
 <label>Division title:</label>
 <input class="form-control" maxlength="250" name="newtitle" size="50" type="text" value="test" />
 </div>
@@ -98,6 +97,7 @@ Read the <a href="http://www.openaustralia.org/debates/?id=2013-03-14.17.1" targ
 <input accesskey="S" class="btn btn-primary" name="submit" type="submit" value="Save" />
 <input class="btn btn-default" name="submit" type="submit" value="Cancel" />
 </form>
+
 <p>
 <a href="/divisions/representatives/2013-03-14/1/history">View change history</a>
 </p>

--- a/spec/fixtures/static_pages/policies/new.html
+++ b/spec/fixtures/static_pages/policies/new.html
@@ -108,8 +108,7 @@ or you can see how it should be broken down, discuss it with others
 and fix it.
 </li>
 </ul>
-<form action="/policies" method="post">
-<div class="form-group">
+<form accept-charset="UTF-8" action="/policies" class="new_policy" id="new_policy" method="post"><div style="display:none"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group">
 <label>If you are for</label>
 <input class="form-control" maxlength="50" name="name" placeholder="equal treatment of same-sex couples" size="40" type="text" value="" />
 </div>
@@ -127,6 +126,7 @@ record public.
 </p>
 <input class="btn btn-primary" name="submit" type="submit" value="Make Policy" />
 </form>
+
 
 </div>
 <div id="footer1">

--- a/spec/fixtures/static_pages/policies_2.html
+++ b/spec/fixtures/static_pages/policies_2.html
@@ -59,8 +59,7 @@ Make a new policy
 <h2>Creating a new policy not complete, please try again</h2>
 <p>Please name your policy, and give a definition.</p>
 </div>
-<form action="/policies" method="post">
-<div class="form-group">
+<form accept-charset="UTF-8" action="/policies" class="new_policy" id="new_policy" method="post"><div style="display:none"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group">
 <label>If you are for</label>
 <input class="form-control" maxlength="50" name="name" placeholder="equal treatment of same-sex couples" size="40" type="text" value="" />
 </div>
@@ -78,6 +77,7 @@ record public.
 </p>
 <input class="btn btn-primary" name="submit" type="submit" value="Make Policy" />
 </form>
+
 
 </div>
 <div id="footer1">

--- a/spec/fixtures/static_pages/policies_3.html
+++ b/spec/fixtures/static_pages/policies_3.html
@@ -59,8 +59,7 @@ Make a new policy
 <h2>Creating a new policy not complete, please try again</h2>
 <p>Please name your policy, and give a definition.</p>
 </div>
-<form action="/policies" method="post">
-<div class="form-group">
+<form accept-charset="UTF-8" action="/policies" class="new_policy" id="new_policy" method="post"><div style="display:none"><input name="utf8" type="hidden" value="&#x2713;" /></div><div class="form-group">
 <label>If you are for</label>
 <input class="form-control" maxlength="50" name="name" placeholder="equal treatment of same-sex couples" size="40" type="text" value="Pro-nuclear power" />
 </div>
@@ -78,6 +77,7 @@ record public.
 </p>
 <input class="btn btn-primary" name="submit" type="submit" value="Make Policy" />
 </form>
+
 
 </div>
 <div id="footer1">


### PR DESCRIPTION
This removes the lines disabling CSRF protection, and switches the manual form tags back over to `form_for`.

(Fixes #445.)
