### PR TITLE
Only show member's image if it exists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :test do
   # the same database. So, using database_cleaner instead
   gem "database_cleaner"
   gem 'rspec-activemodel-mocks'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.6)
     arel (5.0.1.20140414130214)
     attribute-defaults (0.7.0)
       activerecord (>= 4.0.0, < 5.0.0)
@@ -79,6 +80,8 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     colorize (0.7.3)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     daemons (1.1.9)
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
@@ -247,6 +250,7 @@ GEM
       sshkit (>= 1.2)
     safe_attributes (1.0.10)
       activerecord (>= 3.0.0)
+    safe_yaml (1.0.3)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -310,6 +314,9 @@ GEM
     unf_ext (0.0.6)
     warden (1.2.3)
       rack (>= 1.0)
+    webmock (1.18.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     webrobots (0.1.1)
 
 PLATFORMS
@@ -361,3 +368,4 @@ DEPENDENCIES
   therubyracer
   turbolinks
   uglifier (>= 1.3.0)
+  webmock

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -12,7 +12,7 @@ class Member < ActiveRecord::Base
   has_many :divisions, through: :votes
   has_many :member_distances, foreign_key: :member1_id
 
-  delegate :small_image_url, :large_image_url, to: :person
+  delegate :show_large_image?, :show_small_image?, :small_image_url, :large_image_url, to: :person
 
   # Give it a name like "Kevin Rudd" returns ["Kevin", "Rudd"]
   def self.parse_first_last_name(name)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -64,6 +64,14 @@ class Person
     "http://www.openaustralia.org/images/mpsL/#{id}.jpg"
   end
 
+  def show_large_image?
+    CheckResourceExists.call(self.large_image_url)
+  end
+
+  def show_small_image?
+    CheckResourceExists.call(self.small_image_url)
+  end
+
   def member_who_voted_on_division(division)
     latest_member = members.order(entered_house: :desc).first
     # What we have now in @member is a member related to the person that voted in division but @member wasn't necessarily

--- a/app/views/members/_member_page_header.html.haml
+++ b/app/views/members/_member_page_header.html.haml
@@ -1,5 +1,6 @@
 .page-header
-  = image_tag(member.large_image_url, alt: "Photo of #{@member.name_without_title}", size: "88x115")
+  - if member.show_large_image?
+    = image_tag(member.large_image_url, alt: "Photo of #{@member.name_without_title}", size: "88x115")
   %h1= member.name_without_title
   %p.lead= member_type_party_place_sentence(member)
   - if !member.person.current_offices.empty?

--- a/lib/check_resource_exists.rb
+++ b/lib/check_resource_exists.rb
@@ -1,0 +1,10 @@
+require 'net/http'
+
+class CheckResourceExists
+
+  def self.call(url)
+    uri = URI(url)
+    res = Net::HTTP.start(uri.host) { |http| http.head(uri.path) }
+    res.kind_of? Net::HTTPSuccess
+  end
+end

--- a/spec/lib/check_resource_exists.rb
+++ b/spec/lib/check_resource_exists.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe CheckResourceExists do
+
+  describe '#call' do
+    context "given a URL that returns a 200" do
+      before { stub_request(:any, "example.com/foo/bar.img") }
+
+      it { expect(CheckResourceExists.call("http://example.com/foo/bar.img")).to be_truthy }
+
+    end
+
+    context "given a URL that returns a 500" do
+      before { stub_request(:any, "example.com/foo/bar.img").to_return(:status => [500, "Internal Server Error"]) }
+
+      it { expect(CheckResourceExists.call("http://example.com/foo/bar.img")).to be_falsey }
+
+    end
+
+    context "given a URL that returns a 404" do
+      before { stub_request(:any, "example.com/foo/bar.img").to_return(:status => [404, "Not Found"]) }
+
+      it { expect(CheckResourceExists.call("http://example.com/foo/bar.img")).to be_falsey }
+
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,10 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'html_compare_helper'
+require 'webmock/rspec'
+
+# tests can't make external requests
+WebMock.disable_net_connect!(allow: 'www.openaustralia.org')
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Related to https://github.com/openaustralia/publicwhip/issues/406

Introduces:
- [x] a service class for checking if a resource exists
- [x] modifications to `Person` to include methods that check if the resource associated to the large and small image URLs exist
- [x] usage of these methods in the `member#show` view
- [x] webmock for testing
