### PR TITLE
remove button grey style on members toggle

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -181,6 +181,10 @@ th {
   }
 }
 
+.voter-table-toggle-members {
+  border-color: transparent;
+}
+
 .division-policy {
   .division-policy-statement,
   .button_to,

--- a/app/views/divisions/_summary.html.haml
+++ b/app/views/divisions/_summary.html.haml
@@ -26,7 +26,7 @@
           %td{:class => no_vote_class(whip)}
             = whip.no_votes_including_tells if whip.no_votes_including_tells > 0
           %td
-            %button.btn.glyphicon.glyphicon-chevron-down{:data => {:toggle => 'collapse', :target => '.member-row-' + whip.party.parameterize}}
+            %button.voter-table-toggle-members.btn.btn-default.glyphicon.glyphicon-chevron-down{:data => {:toggle => 'collapse', :target => '.member-row-' + whip.party.parameterize}}
               %span.sr-only show members
 
         - # TODO: Order by minority within party (e.g. rebels first) then majority, then absent

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&house=representatives.html
@@ -118,7 +118,7 @@ Not passed by a small majority
 41
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -149,7 +149,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-country-liberal-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-country-liberal-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -166,7 +166,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-cwm" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-cwm" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -183,7 +183,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-independent" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-independent" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -200,7 +200,7 @@ Not passed by a small majority
 34
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -231,7 +231,7 @@ Not passed by a small majority
 1
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-national-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-national-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -248,7 +248,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-spk" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-spk" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Kevin_Rudd&mpc=Griffith&house=representatives&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Kevin_Rudd&mpc=Griffith&house=representatives&house=representatives.html
@@ -115,7 +115,7 @@ Not passed by a small majority
 41
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -146,7 +146,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-country-liberal-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-country-liberal-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -163,7 +163,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-cwm" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-cwm" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -180,7 +180,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-independent" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-independent" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -197,7 +197,7 @@ Not passed by a small majority
 34
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -228,7 +228,7 @@ Not passed by a small majority
 1
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-national-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-national-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -245,7 +245,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-spk" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-spk" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Tony_Abbott&mpc=Warringah&house=representatives&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Tony_Abbott&mpc=Warringah&house=representatives&house=representatives.html
@@ -115,7 +115,7 @@ Not passed by a small majority
 41
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -146,7 +146,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-country-liberal-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-country-liberal-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -163,7 +163,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-cwm" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-cwm" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -180,7 +180,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-independent" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-independent" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -197,7 +197,7 @@ Not passed by a small majority
 34
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -228,7 +228,7 @@ Not passed by a small majority
 1
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-national-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-national-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -245,7 +245,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-spk" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-spk" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives.html
@@ -115,7 +115,7 @@ Not passed by a small majority
 1
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -139,7 +139,7 @@ Not passed by a small majority
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate.html
@@ -113,7 +113,7 @@ Not passed by a small majority
 1
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-australian-greens" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-australian-greens" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&mpn=Christine_Milne&mpc=Senate&house=senate&house=senate.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&mpn=Christine_Milne&mpc=Senate&house=senate&house=senate.html
@@ -110,7 +110,7 @@ Not passed by a small majority
 1
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-australian-greens" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-australian-greens" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>

--- a/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
+++ b/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
@@ -122,7 +122,7 @@ Not passed by a moderate majority
 5
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-australian-greens" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-australian-greens" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -146,7 +146,7 @@ Tasmania
 29
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-australian-labor-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -163,7 +163,7 @@ Tasmania
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-country-liberal-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-country-liberal-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -180,7 +180,7 @@ Tasmania
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-dpres" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-dpres" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -197,7 +197,7 @@ Tasmania
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-family-first-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-family-first-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -214,7 +214,7 @@ Tasmania
 1
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-independent" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-independent" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -245,7 +245,7 @@ WA
 12
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-liberal-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -276,7 +276,7 @@ WA
 
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-national-party" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-national-party" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>
@@ -293,7 +293,7 @@ WA
 1
 </td>
 <td>
-<button class="btn glyphicon glyphicon-chevron-down" data-target=".member-row-pres" data-toggle="collapse">
+<button class="voter-table-toggle-members btn btn-default glyphicon glyphicon-chevron-down" data-target=".member-row-pres" data-toggle="collapse">
 <span class="sr-only">show members</span>
 </button>
 </td>


### PR DESCRIPTION
Removes the grey background on the toggle members button on vote lists.
- removes non-data-link
- lightens non data side of the screen.

After
![screen shot 2014-09-29 at 11 17 54 am](https://cloud.githubusercontent.com/assets/1239550/4436443/bbe02a68-4776-11e4-91eb-46e33ca7fc4a.png)

Before
![screen shot 2014-09-29 at 11 18 28 am](https://cloud.githubusercontent.com/assets/1239550/4436446/d2415818-4776-11e4-9188-7a9706d8a0f1.png)
