### PR TITLE
format the raw debate text to highlight speakers

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -105,10 +105,6 @@ th {
 
     p:not(.speaker) {
       margin-left: 1em;
-
-      @media (min-width: $screen-sm-min) {
-        // margin-left: 2em;
-      }
     }
   }
 }


### PR DESCRIPTION
Adds a heading style to speakers in the raw debate text to make it more scannable and readable as an actual debate.

Before:

![screen shot 2014-09-29 at 1 39 08 pm](https://cloud.githubusercontent.com/assets/1239550/4437030/83b3323e-478a-11e4-8b2c-20849ba60a56.png)

After:

![screen shot 2014-09-29 at 1 37 09 pm](https://cloud.githubusercontent.com/assets/1239550/4437025/63e4c2a6-478a-11e4-8afd-1f6012c6bb32.png)
