### PR TITLE
change block title from motion to summary

### DIFF
--- a/app/views/divisions/_motion.html.haml
+++ b/app/views/divisions/_motion.html.haml
@@ -12,9 +12,9 @@
 
   .row
     %nav.header-actions.col-md-3
-      = link_to "Edit motion", edit_division_path(division), title: "Edit and improve this description", class: "btn btn-default btn-xs"
+      = link_to "Edit summary", edit_division_path(division), title: "Edit and improve this description", class: "btn btn-default btn-xs"
 
-    %h2.col-md-9 Motion
+    %h2.col-md-9 Summary
   .motion-text
     = division.formatted_motion_text
   %nav.motion-source-info

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&house=representatives.html
@@ -70,9 +70,9 @@ by
 </p>
 <div class="row">
 <nav class="header-actions col-md-3">
-<a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Edit and improve this description">Edit motion</a>
+<a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Edit and improve this description">Edit summary</a>
 </nav>
-<h2 class="col-md-9">Motion</h2>
+<h2 class="col-md-9">Summary</h2>
 </div>
 <div class="motion-text">
 <p>This is some test text. I'd like to illustrate formatting like <em>italics</em> and the following points:</p>

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Kevin_Rudd&mpc=Griffith&house=representatives&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Kevin_Rudd&mpc=Griffith&house=representatives&house=representatives.html
@@ -64,9 +64,9 @@ by
 </p>
 <div class="row">
 <nav class="header-actions col-md-3">
-<a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Edit and improve this description">Edit motion</a>
+<a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Edit and improve this description">Edit summary</a>
 </nav>
-<h2 class="col-md-9">Motion</h2>
+<h2 class="col-md-9">Summary</h2>
 </div>
 <div class="motion-text">
 <p>This is some test text. I'd like to illustrate formatting like <em>italics</em> and the following points:</p>

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Tony_Abbott&mpc=Warringah&house=representatives&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Tony_Abbott&mpc=Warringah&house=representatives&house=representatives.html
@@ -64,9 +64,9 @@ by
 </p>
 <div class="row">
 <nav class="header-actions col-md-3">
-<a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Edit and improve this description">Edit motion</a>
+<a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Edit and improve this description">Edit summary</a>
 </nav>
-<h2 class="col-md-9">Motion</h2>
+<h2 class="col-md-9">Summary</h2>
 </div>
 <div class="motion-text">
 <p>This is some test text. I'd like to illustrate formatting like <em>italics</em> and the following points:</p>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives.html
@@ -70,9 +70,9 @@ by
 </p>
 <div class="row">
 <nav class="header-actions col-md-3">
-<a class="btn btn-default btn-xs" href="/divisions/representatives/2013-03-14/1/edit" title="Edit and improve this description">Edit motion</a>
+<a class="btn btn-default btn-xs" href="/divisions/representatives/2013-03-14/1/edit" title="Edit and improve this description">Edit summary</a>
 </nav>
-<h2 class="col-md-9">Motion</h2>
+<h2 class="col-md-9">Summary</h2>
 </div>
 <div class="motion-text">
 <p>This is some test text.</p>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate.html
@@ -70,9 +70,9 @@ automatically extracted from the debate.
 </p>
 <div class="row">
 <nav class="header-actions col-md-3">
-<a class="btn btn-default btn-xs" href="/divisions/senate/2013-03-14/1/edit" title="Edit and improve this description">Edit motion</a>
+<a class="btn btn-default btn-xs" href="/divisions/senate/2013-03-14/1/edit" title="Edit and improve this description">Edit summary</a>
 </nav>
-<h2 class="col-md-9">Motion</h2>
+<h2 class="col-md-9">Summary</h2>
 </div>
 <div class="motion-text">
 

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&mpn=Christine_Milne&mpc=Senate&house=senate&house=senate.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&mpn=Christine_Milne&mpc=Senate&house=senate&house=senate.html
@@ -64,9 +64,9 @@ automatically extracted from the debate.
 </p>
 <div class="row">
 <nav class="header-actions col-md-3">
-<a class="btn btn-default btn-xs" href="/divisions/senate/2013-03-14/1/edit" title="Edit and improve this description">Edit motion</a>
+<a class="btn btn-default btn-xs" href="/divisions/senate/2013-03-14/1/edit" title="Edit and improve this description">Edit summary</a>
 </nav>
-<h2 class="col-md-9">Motion</h2>
+<h2 class="col-md-9">Summary</h2>
 </div>
 <div class="motion-text">
 

--- a/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
+++ b/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
@@ -78,9 +78,9 @@ by
 </p>
 <div class="row">
 <nav class="header-actions col-md-3">
-<a class="btn btn-default btn-xs" href="/divisions/senate/2009-11-25/8/edit" title="Edit and improve this description">Edit motion</a>
+<a class="btn btn-default btn-xs" href="/divisions/senate/2009-11-25/8/edit" title="Edit and improve this description">Edit summary</a>
 </nav>
-<h2 class="col-md-9">Motion</h2>
+<h2 class="col-md-9">Summary</h2>
 </div>
 <div class="motion-text">
 <p>And a great new description</p>


### PR DESCRIPTION
Changes the title of the section ‘Motion’ to ‘Summary’ on the divisions#show. Seems a bit more intuitive because the motion is not what is there, but rather it contains a summary of what happened that should include the motion.

This probably relates to #584 .

![screen shot 2014-09-29 at 3 15 01 pm](https://cloud.githubusercontent.com/assets/1239550/4437457/f8703a6a-4797-11e4-8abd-e994855a8a68.png)
