### PR TITLE
Use raw SQL in MemberDistance calculations

### DIFF
--- a/app/models/member_distance.rb
+++ b/app/models/member_distance.rb
@@ -28,49 +28,103 @@ class MemberDistance < ActiveRecord::Base
   end
 
   def self.calculate_distances(member1, member2)
+    m1_id, m1_entered_house, m1_left_house  = member1.id, member1.entered_house, member2.left_house
+    m2_id, m2_entered_house, m2_left_house  = member2.id, member2.entered_house, member2.left_house
     result = {
-      nvotessame: MemberDistance.calculate_nvotessame(member1, member2),
-      nvotesdiffer: MemberDistance.calculate_nvotesdiffer(member1, member2),
-      nvotesabsent: MemberDistance.calculate_nvotesabsent(member1, member2)
+      nvotessame: MemberDistance.calculate_nvotessame(m1_id, m2_id),
+      nvotesdiffer: MemberDistance.calculate_nvotesdiffer(m1_id, m2_id),
+      nvotesabsent: MemberDistance.calculate_nvotesabsent(m1_id, m1_entered_house, m1_left_house, m2_id, m2_entered_house, m2_left_house)
     }
     result[:distance_a] = Distance.distance_a(result[:nvotessame], result[:nvotesdiffer], result[:nvotesabsent])
     result[:distance_b] = Distance.distance_b(result[:nvotessame], result[:nvotesdiffer])
     result
   end
 
-  def self.calculate_nvotessame(member1, member2)
+  def self.calculate_nvotessame(member1_id, member2_id)
     # TODO Move knowledge of tells out of here. Shouldn't have to know about this to do this
     # kind of query
-    Division
-      .joins("LEFT JOIN votes AS votes1 on votes1.division_id = divisions.id")
-      .joins("LEFT JOIN votes AS votes2 on votes2.division_id = divisions.id")
-      .where("votes1.member_id = ?", member1.id)
-      .where("votes2.member_id = ?", member2.id)
-      .where("(votes1.vote = 'aye' AND votes2.vote = 'aye') OR (votes1.vote = 'no' AND votes2.vote = 'no')")
-      .count
+    # Division
+    #   .joins("LEFT JOIN votes AS votes1 on votes1.division_id = divisions.id")
+    #   .joins("LEFT JOIN votes AS votes2 on votes2.division_id = divisions.id")
+    #   .where("votes1.member_id = ?", member1_id)
+    #   .where("votes2.member_id = ?", member2_id)
+    #   .where("(votes1.vote = 'aye' AND votes2.vote = 'aye') OR (votes1.vote = 'no' AND votes2.vote = 'no')")
+    #   .count
+
+    nvs_sql = %Q{
+SELECT
+  COUNT(*)
+FROM
+  divisions
+INNER JOIN
+  votes AS votes1 on votes1.division_id = divisions.id
+LEFT JOIN
+  votes AS votes2 on votes2.division_id = divisions.id
+WHERE
+  (votes1.member_id = '#{member1_id}') AND
+  (votes2.member_id = '#{member2_id}') AND
+  ((votes1.vote = 'aye' AND votes2.vote = 'aye') OR
+   (votes1.vote = 'no' AND votes2.vote = 'no'))
+}
+    ActiveRecord::Base.connection.execute(nvs_sql).first.first
   end
 
-  def self.calculate_nvotesdiffer(member1, member2)
-    Division
-      .joins("LEFT JOIN votes AS votes1 on votes1.division_id = divisions.id")
-      .joins("LEFT JOIN votes AS votes2 on votes2.division_id = divisions.id")
-      .where("votes1.member_id = ?", member1.id)
-      .where("votes2.member_id = ?", member2.id)
-      .where("(votes1.vote = 'aye' AND votes2.vote = 'no') OR (votes1.vote = 'no' AND votes2.vote = 'aye')")
-      .count
+  def self.calculate_nvotesdiffer(member1_id, member2_id)
+    # Division
+    #   .joins("LEFT JOIN votes AS votes1 on votes1.division_id = divisions.id")
+    #   .joins("LEFT JOIN votes AS votes2 on votes2.division_id = divisions.id")
+    #   .where("votes1.member_id = ?", member1_id)
+    #   .where("votes2.member_id = ?", member2_id)
+    #   .where("(votes1.vote = 'aye' AND votes2.vote = 'no') OR (votes1.vote = 'no' AND votes2.vote = 'aye')")
+    #   .count
+
+    nvd_sql = %Q{
+SELECT
+  COUNT(*)
+FROM
+  divisions
+LEFT JOIN
+  votes AS votes1 on votes1.division_id = divisions.id
+LEFT JOIN
+  votes AS votes2 on votes2.division_id = divisions.id
+WHERE
+  (votes1.member_id = '#{member1_id}') AND
+  (votes2.member_id = '#{member2_id}') AND
+  ((votes1.vote = 'aye' AND votes2.vote = 'no') OR
+   (votes1.vote = 'no' AND votes2.vote = 'aye'))
+}
+
+    ActiveRecord::Base.connection.execute(nvd_sql).first.first
   end
 
   # Count the number of times one of the two members is absent (but not both)
   # someone is absent only if they could vote on a division but didn't
-  def self.calculate_nvotesabsent(member1, member2)
-    Division
-      .where("divisions.date >= ?", member1.entered_house)
-      .where("divisions.date <= ?", member1.left_house)
-      .where("divisions.date >= ?", member2.entered_house)
-      .where("divisions.date <= ?", member2.left_house)
-      .joins("LEFT JOIN votes AS votes1 on votes1.division_id = divisions.id AND votes1.member_id = #{member1.id}")
-      .joins("LEFT JOIN votes AS votes2 on votes2.division_id = divisions.id AND votes2.member_id = #{member2.id}")
-      .where("(votes1.vote IS NULL AND votes2.vote IS NOT NULL) OR (votes1.vote IS NOT NULL AND votes2.vote IS NULL)")
-      .count
+  def self.calculate_nvotesabsent(member1_id, member1_entered_house, member1_left_house, member2_id, member2_entered_house, member2_left_house)
+    # Division
+    #   .where("divisions.date >= ?", member1_entered_house)
+    #   .where("divisions.date <= ?", member1_left_house)
+    #   .where("divisions.date >= ?", member2_entered_house)
+    #   .where("divisions.date <= ?", member2_left_house)
+    #   .joins("LEFT JOIN votes AS votes1 on votes1.division_id = divisions.id AND votes1.member_id = #{member1_id}")
+    #   .joins("LEFT JOIN votes AS votes2 on votes2.division_id = divisions.id AND votes2.member_id = #{member2_id}")
+    #   .where("(votes1.vote IS NULL AND votes2.vote IS NOT NULL) OR (votes1.vote IS NOT NULL AND votes2.vote IS NULL)")
+    #   .count
+
+    nva_sql = %Q{
+SELECT
+  COUNT(*)
+FROM
+  divisions
+LEFT JOIN
+  votes AS votes1 on votes1.division_id = divisions.id AND votes1.member_id = '#{member1_id}'
+LEFT JOIN
+  votes AS votes2 on votes2.division_id = divisions.id AND votes2.member_id = '#{member2_id}'
+WHERE
+  (divisions.date >= '#{member1_entered_house}') AND (divisions.date <= '#{member1_left_house}') AND
+  (divisions.date >= '#{member2_entered_house}') AND (divisions.date <= '#{member2_left_house}') AND
+  ((votes1.vote IS NULL AND votes2.vote IS NOT NULL) OR (votes1.vote IS NOT NULL AND votes2.vote IS NULL))
+}
+
+    ActiveRecord::Base.connection.execute(nva_sql).first.first
   end
 end

--- a/spec/models/member_distance_spec.rb
+++ b/spec/models/member_distance_spec.rb
@@ -21,16 +21,16 @@ describe MemberDistance, type: :model do
       title: "", constituency: "bar", party: "Party", house: "commons",
       entered_house: Date.new(1999,1,1), left_house: Date.new(2010,1,1)) }
 
-    it { expect(MemberDistance.calculate_nvotessame(membera, memberb)).to eq 0 }
-    it { expect(MemberDistance.calculate_nvotesdiffer(membera, memberb)).to eq 0}
-    it { expect(MemberDistance.calculate_nvotesabsent(membera, memberb)).to eq 0}
+    it { expect(MemberDistance.calculate_nvotessame(membera.id, memberb.id)).to eq 0 }
+    it { expect(MemberDistance.calculate_nvotesdiffer(membera.id, memberb.id)).to eq 0}
+    it { expect(MemberDistance.calculate_nvotesabsent(membera.id, membera.entered_house, membera.left_house, memberb.id, memberb.entered_house, memberb.left_house)).to eq 0}
 
     def check_vote_combination(vote1, teller1, vote2, teller2, same, differ, absent)
       membera.votes.create(division: division, vote: vote1, teller: teller1) unless vote1 == "absent"
       memberb.votes.create(division: division, vote: vote2, teller: teller2) unless vote2 == "absent"
-      expect(MemberDistance.calculate_nvotessame(membera, memberb)).to eq same
-      expect(MemberDistance.calculate_nvotesdiffer(membera, memberb)).to eq differ
-      expect(MemberDistance.calculate_nvotesabsent(membera, memberb)).to eq absent
+      expect(MemberDistance.calculate_nvotessame(membera.id, memberb.id)).to eq same
+      expect(MemberDistance.calculate_nvotesdiffer(membera.id, memberb.id)).to eq differ
+      expect(MemberDistance.calculate_nvotesabsent(membera.id, membera.entered_house, membera.left_house, memberb.id, memberb.entered_house, memberb.left_house)).to eq absent
     end
 
     context "with votes in one division that only member A could vote on" do
@@ -107,9 +107,9 @@ describe MemberDistance, type: :model do
         memberb.votes.create(division: division5, vote: "no")
       end
 
-      it { expect(MemberDistance.calculate_nvotessame(membera, memberb)).to eq 2 }
-      it { expect(MemberDistance.calculate_nvotesdiffer(membera, memberb)).to eq 1 }
-      it { expect(MemberDistance.calculate_nvotesabsent(membera, memberb)).to eq 2 }
+      it { expect(MemberDistance.calculate_nvotessame(membera.id, memberb.id)).to eq 2 }
+      it { expect(MemberDistance.calculate_nvotesdiffer(membera.id, memberb.id)).to eq 1 }
+      it { expect(MemberDistance.calculate_nvotesabsent(membera.id, membera.entered_house, membera.left_house, memberb.id, memberb.entered_house, memberb.left_house)).to eq 2 }
 
       it ".calculate_distances" do
         expect(Distance).to receive(:distance_a).with(2, 1, 2).and_return(0.1)


### PR DESCRIPTION
Results in around a 50% decrease in the time of
the rake application:cache:member_distances task

Addresses issue: https://github.com/openaustralia/publicwhip/issues/602
