### PR TITLE
moves notice above page header

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -338,6 +338,13 @@ th {
   }
 }
 
+.alert-container {
+  .alert {
+    margin-bottom: 0;
+    border: 0;
+  }
+}
+
 // section-header
 
 .section-header {

--- a/app/views/layouts/_bootstrap_flash.html.haml
+++ b/app/views/layouts/_bootstrap_flash.html.haml
@@ -1,5 +1,6 @@
 - flash.each do |name, msg|
   - if msg.is_a?(String)
-    %div{class: "alert alert-" + (name.to_s == "notice" ? "success" : "danger")}
-      %button.close(type="button" data-dismiss="alert" aria-hidden="true") &times;
-      %div{id: "flash_#{name}"}= msg
+    %div{class: "alert-container alert-" + (name.to_s == "notice" ? "success" : "danger")}
+      %div{class: "container alert alert-" + (name.to_s == "notice" ? "success" : "danger")}
+        %button.close(type="button" data-dismiss="alert" aria-hidden="true") &times;
+        %div{id: "flash_#{name}"}= msg

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -64,10 +64,10 @@
                     Submit
                   %span.glyphicon.glyphicon-search
 
+    = render "layouts/bootstrap_flash"
     = yield :header
 
     .container
-      = render "layouts/bootstrap_flash"
       = yield
     %footer.site-footer
       .container

--- a/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
+++ b/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
@@ -70,13 +70,15 @@ Submit
 </form>
 </div>
 </nav>
-
-<div class="container">
-<div class="alert alert-success">
+<div class="alert-container alert-success">
+<div class="container alert alert-success">
 <button aria-hidden="true" class="close" data-dismiss="alert" type="button">&times;</button>
 <div id="flash_notice">Division updated</div>
 </div>
+</div>
 
+
+<div class="container">
 <div class="page-header division-header">
 <h1 class="division-title">
 <small class="pre-title">25 Nov 2009 at 16:13, Senate</small>

--- a/spec/fixtures/static_pages/policies.html
+++ b/spec/fixtures/static_pages/policies.html
@@ -69,13 +69,15 @@ Submit
 </form>
 </div>
 </nav>
-
-<div class="container">
-<div class="alert alert-success">
+<div class="alert-container alert-success">
+<div class="container alert alert-success">
 <button aria-hidden="true" class="close" data-dismiss="alert" type="button">&times;</button>
 <div id="flash_notice">Successfully made new policy</div>
 </div>
+</div>
 
+
+<div class="container">
 <div class="page-header row">
 <nav class="header-actions col-md-3">
 <a class="btn btn-default btn-xs" href="/policies/4/edit" title="Change title and definition of policy">Edit</a>

--- a/spec/fixtures/static_pages/policies/1.html
+++ b/spec/fixtures/static_pages/policies/1.html
@@ -69,13 +69,15 @@ Submit
 </form>
 </div>
 </nav>
-
-<div class="container">
-<div class="alert alert-success">
+<div class="alert-container alert-success">
+<div class="container alert alert-success">
 <button aria-hidden="true" class="close" data-dismiss="alert" type="button">&times;</button>
 <div id="flash_notice">Policy updated.</div>
 </div>
+</div>
 
+
+<div class="container">
 <div class="page-header row">
 <nav class="header-actions col-md-3">
 <a class="btn btn-default btn-xs" href="/policies/1/edit" title="Change title and definition of policy">Edit</a>

--- a/spec/fixtures/static_pages/policies/2.html
+++ b/spec/fixtures/static_pages/policies/2.html
@@ -69,13 +69,15 @@ Submit
 </form>
 </div>
 </nav>
-
-<div class="container">
-<div class="alert alert-success">
+<div class="alert-container alert-success">
+<div class="container alert alert-success">
 <button aria-hidden="true" class="close" data-dismiss="alert" type="button">&times;</button>
 <div id="flash_notice">Policy updated.</div>
 </div>
+</div>
 
+
+<div class="container">
 <div class="page-header row">
 <nav class="header-actions col-md-3">
 <a class="btn btn-default btn-xs" href="/policies/2/edit" title="Change title and definition of policy">Edit</a>

--- a/spec/fixtures/static_pages/policies/2_2.html
+++ b/spec/fixtures/static_pages/policies/2_2.html
@@ -69,13 +69,15 @@ Submit
 </form>
 </div>
 </nav>
-
-<div class="container">
-<div class="alert alert-danger">
+<div class="alert-container alert-danger">
+<div class="container alert alert-danger">
 <button aria-hidden="true" class="close" data-dismiss="alert" type="button">&times;</button>
 <div id="flash_alert">Could not update policy.</div>
 </div>
+</div>
 
+
+<div class="container">
 <div class="page-header row">
 <nav class="header-actions col-md-3">
 <a href="/policies/2/history">History of edits</a>

--- a/spec/fixtures/static_pages/policies/2_3.html
+++ b/spec/fixtures/static_pages/policies/2_3.html
@@ -69,13 +69,15 @@ Submit
 </form>
 </div>
 </nav>
-
-<div class="container">
-<div class="alert alert-danger">
+<div class="alert-container alert-danger">
+<div class="container alert alert-danger">
 <button aria-hidden="true" class="close" data-dismiss="alert" type="button">&times;</button>
 <div id="flash_alert">Could not update policy.</div>
 </div>
+</div>
 
+
+<div class="container">
 <div class="page-header row">
 <nav class="header-actions col-md-3">
 <a href="/policies/2/history">History of edits</a>

--- a/spec/fixtures/static_pages/policies_2.html
+++ b/spec/fixtures/static_pages/policies_2.html
@@ -69,13 +69,15 @@ Submit
 </form>
 </div>
 </nav>
-
-<div class="container">
-<div class="alert alert-danger">
+<div class="alert-container alert-danger">
+<div class="container alert alert-danger">
 <button aria-hidden="true" class="close" data-dismiss="alert" type="button">&times;</button>
 <div id="flash_alert">Creating a new policy not complete, please try again</div>
 </div>
+</div>
 
+
+<div class="container">
 <div class="page-header">
 <h1>Make a new policy</h1>
 </div>

--- a/spec/fixtures/static_pages/policies_3.html
+++ b/spec/fixtures/static_pages/policies_3.html
@@ -69,13 +69,15 @@ Submit
 </form>
 </div>
 </nav>
-
-<div class="container">
-<div class="alert alert-danger">
+<div class="alert-container alert-danger">
+<div class="container alert alert-danger">
 <button aria-hidden="true" class="close" data-dismiss="alert" type="button">&times;</button>
 <div id="flash_alert">Creating a new policy not complete, please try again</div>
 </div>
+</div>
 
+
+<div class="container">
 <div class="page-header">
 <h1>Make a new policy</h1>
 </div>


### PR DESCRIPTION
Moves the notice above the header, flush with the navbar.

![screen shot 2014-10-06 at 6 19 14 pm](https://cloud.githubusercontent.com/assets/1239550/4522480/85432092-4d29-11e4-9fd7-7ecf17dc8ff6.png)
![screen shot 2014-10-06 at 6 19 03 pm](https://cloud.githubusercontent.com/assets/1239550/4522479/853ebb2e-4d29-11e4-8198-fcbb9caeb6c8.png)

closes #596
