### PR TITLE
limit line length of motion text

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -115,6 +115,11 @@ th {
 
 // Divisions
 
+.motion-text {
+  float: none;
+  clear: right;
+}
+
 .motion-source-info {
   border-top: 1px solid #E7E7E7;
 }

--- a/app/views/divisions/_motion.html.haml
+++ b/app/views/divisions/_motion.html.haml
@@ -15,7 +15,7 @@
       = link_to "Edit summary", edit_division_path(division), title: "Edit and improve this description", class: "btn btn-default btn-xs"
 
     %h2.col-md-9 Summary
-  .motion-text
+  .motion-text.col-md-8.row
     = division.formatted_motion_text
   %nav.motion-source-info
     %ul.list-inline.nav.nav-pills

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&house=representatives.html
@@ -81,7 +81,7 @@ by
 </nav>
 <h2 class="col-md-9">Summary</h2>
 </div>
-<div class="motion-text">
+<div class="motion-text col-md-8 row">
 <p>This is some test text. I'd like to illustrate formatting like <em>italics</em> and the following points:</p>
 <ul><li>My first point is simple</li><li>But I do have other points to</li><li>And sometimes I do go on</li></ul>
 <p>To back up my arguments I ensure that I link to official sources like the <a href="http://aph.gov.au">APH Official website</a>.</p>

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Kevin_Rudd&mpc=Griffith&house=representatives&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Kevin_Rudd&mpc=Griffith&house=representatives&house=representatives.html
@@ -81,7 +81,7 @@ by
 </nav>
 <h2 class="col-md-9">Summary</h2>
 </div>
-<div class="motion-text">
+<div class="motion-text col-md-8 row">
 <p>This is some test text. I'd like to illustrate formatting like <em>italics</em> and the following points:</p>
 <ul><li>My first point is simple</li><li>But I do have other points to</li><li>And sometimes I do go on</li></ul>
 <p>To back up my arguments I ensure that I link to official sources like the <a href="http://aph.gov.au">APH Official website</a>.</p>

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Tony_Abbott&mpc=Warringah&house=representatives&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Tony_Abbott&mpc=Warringah&house=representatives&house=representatives.html
@@ -81,7 +81,7 @@ by
 </nav>
 <h2 class="col-md-9">Summary</h2>
 </div>
-<div class="motion-text">
+<div class="motion-text col-md-8 row">
 <p>This is some test text. I'd like to illustrate formatting like <em>italics</em> and the following points:</p>
 <ul><li>My first point is simple</li><li>But I do have other points to</li><li>And sometimes I do go on</li></ul>
 <p>To back up my arguments I ensure that I link to official sources like the <a href="http://aph.gov.au">APH Official website</a>.</p>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives.html
@@ -81,7 +81,7 @@ by
 </nav>
 <h2 class="col-md-9">Summary</h2>
 </div>
-<div class="motion-text">
+<div class="motion-text col-md-8 row">
 <p>This is some test text.</p>
 <p>It might relate to bills containing HTML characters like the Carbon Pollution Reduction Scheme Bill 2009 and Bills — National Disability Insurance Scheme Bill</p>
 

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate.html
@@ -81,7 +81,7 @@ automatically extracted from the debate.
 </nav>
 <h2 class="col-md-9">Summary</h2>
 </div>
-<div class="motion-text">
+<div class="motion-text col-md-8 row">
 
 </div>
 <nav class="motion-source-info">

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&mpn=Christine_Milne&mpc=Senate&house=senate&house=senate.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&mpn=Christine_Milne&mpc=Senate&house=senate&house=senate.html
@@ -81,7 +81,7 @@ automatically extracted from the debate.
 </nav>
 <h2 class="col-md-9">Summary</h2>
 </div>
-<div class="motion-text">
+<div class="motion-text col-md-8 row">
 
 </div>
 <nav class="motion-source-info">

--- a/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
+++ b/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
@@ -97,7 +97,7 @@ by
 </nav>
 <h2 class="col-md-9">Summary</h2>
 </div>
-<div class="motion-text">
+<div class="motion-text col-md-8 row">
 <p>And a great new description</p>
 
 </div>


### PR DESCRIPTION
The motion text now only even gets to be 8 cols wide on wide screens. This helps reading and opens up some space (see #657 ).

![screen shot 2014-10-07 at 5 08 42 pm](https://cloud.githubusercontent.com/assets/1239550/4538088/c159a91e-4de9-11e4-8f28-4be891eb74ae.png)
![screen shot 2014-10-07 at 5 08 46 pm](https://cloud.githubusercontent.com/assets/1239550/4538089/c15d5a32-4de9-11e4-98c1-fef0e17fdc46.png)

Closes #630 
