### PR TITLE
Divisions lists takes on members list open style

### DIFF
--- a/app/assets/stylesheets/global/_object-list.scss
+++ b/app/assets/stylesheets/global/_object-list.scss
@@ -1,3 +1,12 @@
+.object-item {
+  border-top: 1px solid $gray-lighter;
+  padding-top: 1em;
+  padding-right: 15px;
+  padding-bottom: 1.5em;
+  padding-left: 15px;
+  @include clearfix;
+}
+
 .object-primary {
   margin-bottom: 0;
 

--- a/app/assets/stylesheets/members/_member-list.scss
+++ b/app/assets/stylesheets/members/_member-list.scss
@@ -1,10 +1,4 @@
 .members-list {
-  .member-item {
-    border-top: 1px solid $gray-lighter;
-    padding-top: 1em;
-    padding-bottom: 1.5em;
-  }
-
   .member-photo {
     max-width: 44px;
   }

--- a/app/views/divisions/_division.html.haml
+++ b/app/views/divisions/_division.html.haml
@@ -1,6 +1,6 @@
 %li
-  = link_to division, class: 'panel panel-default panel-link', title: "See full division page for #{truncate(division.name, length: 180)}." do
-    %article.division-item.panel-body{class: division_edit_status_class(division)}
+  = link_to division, class: 'object-item panel-link', title: "See full division page for #{truncate(division.name, length: 180)}." do
+    %article.division-item{class: division_edit_status_class(division)}
       .division-edit-notice.pull-right.text-muted
         - if division.edited?
           edited

--- a/app/views/members/_members.html.haml
+++ b/app/views/members/_members.html.haml
@@ -1,7 +1,7 @@
 %ol.members-list.list-unstyled{:class => active_house_for_list_class(house)}
   - members.each do |member|
     %li
-      = link_to member, class: 'member-item panel-link' do
+      = link_to member, class: 'member-item object-item panel-link' do
         %article.media
           = image_tag(member.small_image_url, alt: "Photo of #{member.name_without_title}", class: "member-photo pull-left")
           .media-body

--- a/spec/fixtures/static_pages/.html
+++ b/spec/fixtures/static_pages/.html
@@ -87,7 +87,7 @@ or
 </p>
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -112,7 +112,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=rebellions.html
@@ -117,7 +117,7 @@ Rebellions
 
 <ol class="display-house-representatives divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=subject.html
@@ -116,7 +116,7 @@ Sorted Alphabetically
 
 <ol class="display-house-representatives divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives&sort=turnout.html
@@ -117,7 +117,7 @@ Attendance
 
 <ol class="display-house-representatives divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&house=representatives.html
@@ -114,7 +114,7 @@ Sorted by Date
 
 <ol class="display-house-representatives divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=rebellions.html
@@ -115,7 +115,7 @@ Rebellions
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=subject.html
@@ -114,7 +114,7 @@ Sorted Alphabetically
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004&sort=turnout.html
@@ -115,7 +115,7 @@ Attendance
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2004.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2004.html
@@ -112,7 +112,7 @@ Sorted by Date
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=rebellions.html
@@ -117,7 +117,7 @@ Rebellions
 
 <ol class="display-house-senate divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -141,7 +141,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -165,7 +165,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=subject.html
@@ -116,7 +116,7 @@ Sorted Alphabetically
 
 <ol class="display-house-senate divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -140,7 +140,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -164,7 +164,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate&sort=turnout.html
@@ -117,7 +117,7 @@ Attendance
 
 <ol class="display-house-senate divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -141,7 +141,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -165,7 +165,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&house=senate.html
@@ -114,7 +114,7 @@ Sorted by Date
 
 <ol class="display-house-senate divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -138,7 +138,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -162,7 +162,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=rebellions.html
@@ -115,7 +115,7 @@ Rebellions
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -139,7 +139,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -163,7 +163,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=subject.html
@@ -114,7 +114,7 @@ Sorted Alphabetically
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -138,7 +138,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -162,7 +162,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007&sort=turnout.html
@@ -115,7 +115,7 @@ Attendance
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -139,7 +139,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -163,7 +163,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=2007.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=2007.html
@@ -112,7 +112,7 @@ Sorted by Date
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -136,7 +136,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -160,7 +160,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=rebellions.html
@@ -117,7 +117,7 @@ Rebellions
 
 <ol class="display-house-representatives divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -142,7 +142,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=subject.html
@@ -116,7 +116,7 @@ Sorted Alphabetically
 
 <ol class="display-house-representatives divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -141,7 +141,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives&sort=turnout.html
@@ -117,7 +117,7 @@ Attendance
 
 <ol class="display-house-representatives divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -142,7 +142,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=representatives.html
@@ -114,7 +114,7 @@ Sorted by Date
 
 <ol class="display-house-representatives divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -139,7 +139,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=rebellions.html
@@ -117,7 +117,7 @@ Rebellions
 
 <ol class="display-house-senate divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -141,7 +141,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -165,7 +165,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -189,7 +189,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=subject.html
@@ -116,7 +116,7 @@ Sorted Alphabetically
 
 <ol class="display-house-senate divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -140,7 +140,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -164,7 +164,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -188,7 +188,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate&sort=turnout.html
@@ -117,7 +117,7 @@ Attendance
 
 <ol class="display-house-senate divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -141,7 +141,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -165,7 +165,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -189,7 +189,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&house=senate.html
@@ -114,7 +114,7 @@ Sorted by Date
 
 <ol class="display-house-senate divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -138,7 +138,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -162,7 +162,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -186,7 +186,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=rebellions.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=rebellions.html
@@ -115,7 +115,7 @@ Rebellions
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -139,7 +139,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -163,7 +163,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -188,7 +188,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -212,7 +212,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -236,7 +236,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=subject.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=subject.html
@@ -114,7 +114,7 @@ Sorted Alphabetically
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -139,7 +139,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -163,7 +163,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -187,7 +187,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -211,7 +211,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -235,7 +235,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=turnout.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all&sort=turnout.html
@@ -115,7 +115,7 @@ Attendance
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -140,7 +140,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014
@@ -165,7 +165,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -189,7 +189,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -213,7 +213,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -237,7 +237,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/divisions.php?rdisplay=all.html
+++ b/spec/fixtures/static_pages/divisions.php?rdisplay=all.html
@@ -112,7 +112,7 @@ Sorted by Date
 
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -137,7 +137,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -161,7 +161,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -185,7 +185,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -209,7 +209,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -233,7 +233,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&display=everyvote.html
@@ -90,7 +90,7 @@ attendance
 <p>All votes Senator Christine Milne could have attended.</p>
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -108,7 +108,7 @@ Motions — Renewable Energy Certificates
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -126,7 +126,7 @@ Proceedural ban of flatulence during divisions
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -144,7 +144,7 @@ Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon 
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=everyvote.html
@@ -90,7 +90,7 @@ attendance
 <p>All votes Kevin Rudd MP could have attended.</p>
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -109,7 +109,7 @@ test
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&dmp=1.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&dmp=1.html
@@ -85,7 +85,7 @@ voted compared to someone who believes that
 <section class="page-section" id="divisions">
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013

--- a/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&display=everyvote.html
@@ -90,7 +90,7 @@ attendance
 <p>All votes Tony Abbott MP could have attended.</p>
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -109,7 +109,7 @@ test
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&dmp=1.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&dmp=1.html
@@ -85,7 +85,7 @@ voted compared to someone who believes that
 <section class="page-section" id="divisions">
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013

--- a/spec/fixtures/static_pages/mps.php?house=representatives&sort=attendance.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives&sort=attendance.html
@@ -101,7 +101,7 @@ Sorted by Attendance
 </div>
 <ol class="display-house-representatives list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
 <img alt="Photo of Tony Abbott" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10001.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Tony Abbott</h2>
@@ -124,7 +124,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
 <img alt="Photo of John Alexander" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10725.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">John Alexander</h2>

--- a/spec/fixtures/static_pages/mps.php?house=representatives&sort=constituency.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives&sort=constituency.html
@@ -102,7 +102,7 @@ Electorate
 </div>
 <ol class="display-house-representatives list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
 <img alt="Photo of John Alexander" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10725.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">John Alexander</h2>
@@ -122,7 +122,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
 <img alt="Photo of Tony Abbott" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10001.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Tony Abbott</h2>

--- a/spec/fixtures/static_pages/mps.php?house=representatives&sort=party.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives&sort=party.html
@@ -101,7 +101,7 @@ Sorted by Party
 </div>
 <ol class="display-house-representatives list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
 <img alt="Photo of Tony Abbott" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10001.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Tony Abbott</h2>
@@ -124,7 +124,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
 <img alt="Photo of John Alexander" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10725.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">John Alexander</h2>

--- a/spec/fixtures/static_pages/mps.php?house=representatives&sort=rebellions.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives&sort=rebellions.html
@@ -101,7 +101,7 @@ Sorted by Rebellions
 </div>
 <ol class="display-house-representatives list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
 <img alt="Photo of Tony Abbott" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10001.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Tony Abbott</h2>
@@ -124,7 +124,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
 <img alt="Photo of John Alexander" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10725.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">John Alexander</h2>

--- a/spec/fixtures/static_pages/mps.php?house=representatives.html
+++ b/spec/fixtures/static_pages/mps.php?house=representatives.html
@@ -101,7 +101,7 @@ Sorted by Name
 </div>
 <ol class="display-house-representatives list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
 <img alt="Photo of Tony Abbott" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10001.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Tony Abbott</h2>
@@ -124,7 +124,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/bennelong/john_alexander"><article class="media">
 <img alt="Photo of John Alexander" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10725.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">John Alexander</h2>

--- a/spec/fixtures/static_pages/mps.php?house=senate&sort=attendance.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate&sort=attendance.html
@@ -101,7 +101,7 @@ Sorted by Attendance
 </div>
 <ol class="display-house-senate list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
 <img alt="Photo of Christine Milne" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10458.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christine Milne</h2>
@@ -124,7 +124,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
 <img alt="Photo of Christopher Back" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10722.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christopher Back</h2>

--- a/spec/fixtures/static_pages/mps.php?house=senate&sort=constituency.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate&sort=constituency.html
@@ -102,7 +102,7 @@ State
 </div>
 <ol class="display-house-senate list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
 <img alt="Photo of Christine Milne" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10458.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christine Milne</h2>
@@ -125,7 +125,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
 <img alt="Photo of Christopher Back" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10722.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christopher Back</h2>

--- a/spec/fixtures/static_pages/mps.php?house=senate&sort=party.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate&sort=party.html
@@ -101,7 +101,7 @@ Sorted by Party
 </div>
 <ol class="display-house-senate list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
 <img alt="Photo of Christine Milne" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10458.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christine Milne</h2>
@@ -124,7 +124,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
 <img alt="Photo of Christopher Back" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10722.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christopher Back</h2>

--- a/spec/fixtures/static_pages/mps.php?house=senate&sort=rebellions.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate&sort=rebellions.html
@@ -101,7 +101,7 @@ Sorted by Rebellions
 </div>
 <ol class="display-house-senate list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
 <img alt="Photo of Christopher Back" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10722.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christopher Back</h2>
@@ -124,7 +124,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
 <img alt="Photo of Christine Milne" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10458.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christine Milne</h2>

--- a/spec/fixtures/static_pages/mps.php?house=senate.html
+++ b/spec/fixtures/static_pages/mps.php?house=senate.html
@@ -101,7 +101,7 @@ Sorted by Name
 </div>
 <ol class="display-house-senate list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
 <img alt="Photo of Christopher Back" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10722.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christopher Back</h2>
@@ -124,7 +124,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
 <img alt="Photo of Christine Milne" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10458.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christine Milne</h2>

--- a/spec/fixtures/static_pages/policies/1.html
+++ b/spec/fixtures/static_pages/policies/1.html
@@ -132,7 +132,7 @@ Compare how a supporter of the policy would have voted to the division outcome.
 <section class="page-section" id="divisions">
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013

--- a/spec/fixtures/static_pages/policies/2.html
+++ b/spec/fixtures/static_pages/policies/2.html
@@ -116,7 +116,7 @@ Compare how a supporter of the policy would have voted to the division outcome.
 <section class="page-section" id="divisions">
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -134,7 +134,7 @@ Motions — Renewable Energy Certificates
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/policy.php?id=1.html
+++ b/spec/fixtures/static_pages/policy.php?id=1.html
@@ -116,7 +116,7 @@ Compare how a supporter of the policy would have voted to the division outcome.
 <section class="page-section" id="divisions">
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013

--- a/spec/fixtures/static_pages/policy.php?id=2.html
+++ b/spec/fixtures/static_pages/policy.php?id=2.html
@@ -100,7 +100,7 @@ Compare how a supporter of the policy would have voted to the division outcome.
 <section class="page-section" id="divisions">
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw panel-body">
+<a class="object-item panel-link" href="/divisions/senate/2013-03-14/1" title="See full division page for Motions — Renewable Energy Certificates."><article class="division-item division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
 raw
 </div>
@@ -118,7 +118,7 @@ Motions — Renewable Energy Certificates
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/search.php?query=Kevin&button=Search.html
+++ b/spec/fixtures/static_pages/search.php?query=Kevin&button=Search.html
@@ -65,7 +65,7 @@ Submit
 <h2>1 person</h2>
 <ol class="display-house-all list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/representatives/griffith/kevin_rudd"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/griffith/kevin_rudd"><article class="media">
 <img alt="Photo of Kevin Rudd" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10552.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Kevin Rudd</h2>

--- a/spec/fixtures/static_pages/search.php?query=This+is+some+test+text&button=Search.html
+++ b/spec/fixtures/static_pages/search.php?query=This+is+some+test+text&button=Search.html
@@ -65,7 +65,7 @@ Submit
 <h2>4 people</h2>
 <ol class="display-house-all list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/surly_nihilist"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/surly_nihilist"><article class="media">
 <img alt="Photo of Surly Nihilist" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/33331.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Surly Nihilist</h2>
@@ -86,7 +86,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
 <img alt="Photo of Christopher Back" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10722.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christopher Back</h2>
@@ -109,7 +109,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/disagreeable_curmudgeon"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/disagreeable_curmudgeon"><article class="media">
 <img alt="Photo of Disagreeable Curmudgeon" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/22221.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Disagreeable Curmudgeon</h2>
@@ -130,7 +130,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
 <img alt="Photo of Christine Milne" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10458.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christine Milne</h2>
@@ -157,7 +157,7 @@ attendance
 <h2>2 divisions</h2>
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -182,7 +182,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/search.php?query=This+is+some+test+text&button=Submit.html
+++ b/spec/fixtures/static_pages/search.php?query=This+is+some+test+text&button=Submit.html
@@ -65,7 +65,7 @@ Submit
 <h2>4 people</h2>
 <ol class="display-house-all list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/surly_nihilist"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/surly_nihilist"><article class="media">
 <img alt="Photo of Surly Nihilist" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/33331.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Surly Nihilist</h2>
@@ -86,7 +86,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/christopher_back"><article class="media">
 <img alt="Photo of Christopher Back" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10722.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christopher Back</h2>
@@ -109,7 +109,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/wa/disagreeable_curmudgeon"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/wa/disagreeable_curmudgeon"><article class="media">
 <img alt="Photo of Disagreeable Curmudgeon" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/22221.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Disagreeable Curmudgeon</h2>
@@ -130,7 +130,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="member-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
+<a class="member-item object-item panel-link" href="/members/senate/tasmania/christine_milne"><article class="media">
 <img alt="Photo of Christine Milne" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10458.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Christine Milne</h2>
@@ -157,7 +157,7 @@ attendance
 <h2>2 divisions</h2>
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013
@@ -182,7 +182,7 @@ attendance
 </article>
 </a></li>
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 15th May 2014

--- a/spec/fixtures/static_pages/search.php?query=Tony+Abbott&button=Search.html
+++ b/spec/fixtures/static_pages/search.php?query=Tony+Abbott&button=Search.html
@@ -65,7 +65,7 @@ Submit
 <h2>1 person</h2>
 <ol class="display-house-all list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
 <img alt="Photo of Tony Abbott" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10001.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Tony Abbott</h2>

--- a/spec/fixtures/static_pages/search.php?query=Tony+Abbott&button=Submit.html
+++ b/spec/fixtures/static_pages/search.php?query=Tony+Abbott&button=Submit.html
@@ -65,7 +65,7 @@ Submit
 <h2>1 person</h2>
 <ol class="display-house-all list-unstyled members-list">
 <li>
-<a class="member-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
+<a class="member-item object-item panel-link" href="/members/representatives/warringah/tony_abbott"><article class="media">
 <img alt="Photo of Tony Abbott" class="member-photo pull-left" src="http://www.openaustralia.org/images/mps/10001.jpg" />
 <div class="media-body">
 <h2 class="media-heading member-name panel-link-title">Tony Abbott</h2>

--- a/spec/fixtures/static_pages/search.php?query=supplementary+explanatory+memorandum&button=Search.html
+++ b/spec/fixtures/static_pages/search.php?query=supplementary+explanatory+memorandum&button=Search.html
@@ -65,7 +65,7 @@ Submit
 <h2>1 division</h2>
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013

--- a/spec/fixtures/static_pages/search.php?query=supplementary+explanatory+memorandum&button=Submit.html
+++ b/spec/fixtures/static_pages/search.php?query=supplementary+explanatory+memorandum&button=Submit.html
@@ -65,7 +65,7 @@ Submit
 <h2>1 division</h2>
 <ol class="display-house-all divisions-list list-unstyled">
 <li>
-<a class="panel panel-default panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited panel-body">
+<a class="object-item panel-link" href="/divisions/representatives/2013-03-14/1" title="See full division page for test."><article class="division-item division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
 edited
 20th Oct 2013


### PR DESCRIPTION
Interested in thoughts. This removes the panel style to further unify members and divisions object style ( #739 ). Reduces non-data-ink. Might need a bit more spacing to separate the objects more clearly.

![screen shot 2014-10-16 at 12 41 08 am](https://cloud.githubusercontent.com/assets/1239550/4646214/6b5d8754-5471-11e4-811d-51224f9074d7.png)

Closes #739 
