### PR TITLE
changes the about intro to shorten and remove 'And' beginning sentence.

### DIFF
--- a/app/views/home/about.html.haml
+++ b/app/views/home/about.html.haml
@@ -6,7 +6,7 @@
     .page-header.container
       %h1= yield :title
       %p.lead
-        Forget what politicians <em>say</em>. What truly matters is what they <em>do</em>. And what they do is <em>vote</em>, to write our laws which affect us all.
+        Forget what politicians <em>say</em>. What truly matters is what they&nbsp;<em>do</em>—vote in Parliament on the laws which affect&nbsp;us&nbsp;all.
 
 .row
   .col-md-8


### PR DESCRIPTION
This changes the intro of the About page from:

> Forget what politicians say. What truly matters is what they do. And what they do is vote, to write our laws which affect us all.

to 

> Forget what politicians say. What truly matters is what they do—vote in Parliament on the laws which affect us all.

This is shorter, reads more smoothly without the sentence start 'And', and locates there votes being in 'Parliament' which helps people understand the site.

Also, should it be 'that affect us all' rather than 'which'?
