### PR TITLE
change division outcome symbol to arrow

### DIFF
--- a/app/assets/stylesheets/divisions/_division-list.scss
+++ b/app/assets/stylesheets/divisions/_division-list.scss
@@ -59,7 +59,7 @@
     }
   }
 
-  .division-outcome,
+
   .division-member-vote {
     &:before {
       content: "\00a0\25CF\00a0";
@@ -69,12 +69,16 @@
 
   .division-member-vote.member-voted-yes:before,
   &.division-outcome-passed .division-outcome:before {
-    color: $color-vote-for;
+    content: "\00a0\2192\00a0";
+    color: $text-color;
+    font-weight: bold;
   }
 
 
   .division-member-vote.member-voted-no:before,
    &.division-outcome-not-passed .division-outcome:before {
-    color: $color-vote-against;
+    content: "\00a0\2190\00a0";
+    color: $text-color;
+    font-weight: bold;
   }
 }


### PR DESCRIPTION
Arrows are more neutral than the red, green dots. They also highlight nicely when an mp 'moving' with or against the wider parliament on this motion. The arrow is an distinct symbol, but whether the direction is positive or negative is ambiguous. I think is closer to what we're going for here than the red, green dots. Very interested in perspectives @mlandauer @kat @henare .
## Arrows

![screen shot 2014-10-29 at 11 33 47 am](https://cloud.githubusercontent.com/assets/1239550/4819660/72566ca6-5f07-11e4-85fb-1a083f3499c6.png)
![screen shot 2014-10-29 at 11 43 29 am](https://cloud.githubusercontent.com/assets/1239550/4819658/66f304f0-5f07-11e4-841a-9284c4299a3d.png)
![screen shot 2014-10-29 at 11 58 17 am](https://cloud.githubusercontent.com/assets/1239550/4819656/588061e2-5f07-11e4-991c-3c72a6ca60d7.png)
## Red Green dots

![screen shot 2014-10-29 at 11 58 11 am](https://cloud.githubusercontent.com/assets/1239550/4819653/4e17b124-5f07-11e4-94c6-2afbd3e91dfa.png)
## Arrows with colour (EXAMPLE NOT COMMITTED)

![screen shot 2014-10-29 at 11 40 00 am](https://cloud.githubusercontent.com/assets/1239550/4819666/8d90dfc4-5f07-11e4-801a-9f9b9ae4b209.png)
![screen shot 2014-10-29 at 11 39 49 am](https://cloud.githubusercontent.com/assets/1239550/4819667/8d9d0510-5f07-11e4-8795-590c41e11d9d.png)
