### PR TITLE
Adds an edit button to divisions consistent with policies

### DIFF
--- a/app/views/divisions/_header.html.haml
+++ b/app/views/divisions/_header.html.haml
@@ -1,7 +1,7 @@
 - content_for :title do
   = truncate(division.name, length: 180)
 
-.page-header.division-header
+.page-header.division-header.row
   %nav.header-actions.col-md-1.col-lg-2
     = link_to "Edit", edit_division_path(@division), title: "Change title and summary of this division", class: "btn btn-default btn-xs"
 

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&house=representatives&number=3&display=policies.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&house=representatives&number=3&display=policies.html
@@ -70,7 +70,7 @@ Henare Degan
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&house=representatives.html
@@ -69,7 +69,7 @@ by
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Kevin_Rudd&mpc=Griffith&house=representatives&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Kevin_Rudd&mpc=Griffith&house=representatives&house=representatives.html
@@ -69,7 +69,7 @@ by
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Tony_Abbott&mpc=Warringah&house=representatives&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2006-12-06&number=3&mpn=Tony_Abbott&mpc=Warringah&house=representatives&house=representatives.html
@@ -69,7 +69,7 @@ by
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2009-11-25&number=8&house=senate&display=policies&dmp=1.html
+++ b/spec/fixtures/static_pages/division.php?date=2009-11-25&number=8&house=senate&display=policies&dmp=1.html
@@ -70,7 +70,7 @@ Henare Degan
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/senate/2009-11-25/8/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2009-11-25&number=8&house=senate&display=policies&dmp=2.html
+++ b/spec/fixtures/static_pages/division.php?date=2009-11-25&number=8&house=senate&display=policies&dmp=2.html
@@ -70,7 +70,7 @@ Henare Degan
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/senate/2009-11-25/8/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2009-11-25&number=8&house=senate&display=policies.html
+++ b/spec/fixtures/static_pages/division.php?date=2009-11-25&number=8&house=senate&display=policies.html
@@ -70,7 +70,7 @@ Henare Degan
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/senate/2009-11-25/8/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives&display=policies.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives&display=policies.html
@@ -70,7 +70,7 @@ Henare Degan
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/representatives/2013-03-14/1/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives&display=policies_2.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives&display=policies_2.html
@@ -61,7 +61,7 @@ Submit
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/representatives/2013-03-14/1/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=representatives.html
@@ -69,7 +69,7 @@ by
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/representatives/2013-03-14/1/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate&display=policies.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate&display=policies.html
@@ -70,7 +70,7 @@ Henare Degan
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/senate/2013-03-14/1/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate&display=policies_2.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate&display=policies_2.html
@@ -61,7 +61,7 @@ Submit
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/senate/2013-03-14/1/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&house=senate.html
@@ -61,7 +61,7 @@ Submit
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/senate/2013-03-14/1/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&mpn=Christine_Milne&mpc=Senate&house=senate&house=senate.html
+++ b/spec/fixtures/static_pages/division.php?date=2013-03-14&number=1&mpn=Christine_Milne&mpc=Senate&house=senate&house=senate.html
@@ -61,7 +61,7 @@ Submit
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/senate/2013-03-14/1/edit" title="Change title and summary of this division">Edit</a>
 </nav>

--- a/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
+++ b/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
@@ -84,7 +84,7 @@ by
 
 
 
-<div class="container main-content"><div class="page-header division-header">
+<div class="container main-content"><div class="page-header division-header row">
 <nav class="header-actions col-md-1 col-lg-2">
 <a class="btn btn-default btn-xs" href="/divisions/senate/2009-11-25/8/edit" title="Change title and summary of this division">Edit</a>
 </nav>


### PR DESCRIPTION
Adds a persistent edit link to divisions, exactly like policies. The small screen layout isn't great, but it's consistent with policies and they can be improved together in the next pass.

Closes #927 

![screen shot 2014-10-29 at 1 24 59 pm](https://cloud.githubusercontent.com/assets/1239550/4820270/ef549ba0-5f12-11e4-9154-36ddd3bc341f.png)
![screen shot 2014-10-29 at 1 24 42 pm](https://cloud.githubusercontent.com/assets/1239550/4820272/ef595938-5f12-11e4-96f5-6c9b71cbf9a1.png)
![screen shot 2014-10-29 at 1 24 34 pm](https://cloud.githubusercontent.com/assets/1239550/4820271/ef57c762-5f12-11e4-82cf-250431c07e29.png)
