### PR TITLE
Consistent style for 'all votes' and 'more possible friends' links on members#show

### DIFF
--- a/app/views/members/_possible_friends.html.haml
+++ b/app/views/members/_possible_friends.html.haml
@@ -47,6 +47,6 @@
             %td= link_to_unless member_distance.member2.senator?, member_distance.member2.electorate, electorate_path(member_distance.member2)
             %td= party_long2(member_distance.member2)
   - unless all_friends
-    = link_to "More possible friends", friends_member_path(member)
+    = link_to "More possible friends", friends_member_path(member), class: 'btn btn-default btn-sm'
   - if member.best_friends.count >= 5 && !all_friends
     (#{pluralize(member.best_friends.count, "MP")} voted exactly the same as this one)

--- a/app/views/members/_recent_votes.html.haml
+++ b/app/views/members/_recent_votes.html.haml
@@ -9,5 +9,4 @@
   - member.person.members.order(entered_house: :desc).each do |member|
     = render "divisions/divisions", member: member, divisions: member.divisions_possible.order(date: :desc, clock_time: :desc, name: :asc).limit(3)
 
-  %p
-    See also #{link_to "all votes", [member, Division]}.
+  =link_to "View all votes", [member, Division], class: 'btn btn-default btn-sm'

--- a/spec/fixtures/static_pages/mp.php?mpn=Barnaby_Joyce&mpc=New_England&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Barnaby_Joyce&mpc=New_England&house=representatives.html
@@ -211,9 +211,7 @@ attendance
 
 </ol>
 
-<p>
-See also <a href="/people/representatives/new_england/barnaby_joyce/divisions">all votes</a>.
-</p>
+<a class="btn btn-default btn-sm" href="/people/representatives/new_england/barnaby_joyce/divisions">View all votes</a>
 </section>
 
 <section class="page-section" id="friends">
@@ -248,7 +246,7 @@ that were previously unsuspected. Or it may be nonsense.
 </tr>
 </tbody>
 </table>
-<a href="/people/representatives/new_england/barnaby_joyce/friends">More possible friends</a>
+<a class="btn btn-default btn-sm" href="/people/representatives/new_england/barnaby_joyce/friends">More possible friends</a>
 </section>
 
 </div>

--- a/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate.html
@@ -215,9 +215,7 @@ attendance
 
 </ol>
 
-<p>
-See also <a href="/people/senate/tasmania/christine_milne/divisions">all votes</a>.
-</p>
+<a class="btn btn-default btn-sm" href="/people/senate/tasmania/christine_milne/divisions">View all votes</a>
 </section>
 
 <section class="page-section" id="friends">
@@ -255,7 +253,7 @@ that were previously unsuspected. Or it may be nonsense.
 </tr>
 </tbody>
 </table>
-<a href="/people/senate/tasmania/christine_milne/friends">More possible friends</a>
+<a class="btn btn-default btn-sm" href="/people/senate/tasmania/christine_milne/friends">More possible friends</a>
 </section>
 
 </div>

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives.html
@@ -250,9 +250,7 @@ attendance
 
 </ol>
 
-<p>
-See also <a href="/people/representatives/griffith/kevin_rudd/divisions">all votes</a>.
-</p>
+<a class="btn btn-default btn-sm" href="/people/representatives/griffith/kevin_rudd/divisions">View all votes</a>
 </section>
 
 <section class="page-section" id="friends">
@@ -287,7 +285,7 @@ that were previously unsuspected. Or it may be nonsense.
 </tr>
 </tbody>
 </table>
-<a href="/people/representatives/griffith/kevin_rudd/friends">More possible friends</a>
+<a class="btn btn-default btn-sm" href="/people/representatives/griffith/kevin_rudd/friends">More possible friends</a>
 </section>
 
 </div>

--- a/spec/fixtures/static_pages/mp.php?mpn=Roger_Price&mpc=Chifley&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Roger_Price&mpc=Chifley&house=representatives.html
@@ -211,9 +211,7 @@ attendance
 
 </ol>
 
-<p>
-See also <a href="/people/representatives/chifley/roger_price/divisions">all votes</a>.
-</p>
+<a class="btn btn-default btn-sm" href="/people/representatives/chifley/roger_price/divisions">View all votes</a>
 </section>
 
 <section class="page-section" id="friends">
@@ -248,7 +246,7 @@ that were previously unsuspected. Or it may be nonsense.
 </tr>
 </tbody>
 </table>
-<a href="/people/representatives/chifley/roger_price/friends">More possible friends</a>
+<a class="btn btn-default btn-sm" href="/people/representatives/chifley/roger_price/friends">More possible friends</a>
 </section>
 
 </div>

--- a/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives.html
@@ -250,9 +250,7 @@ attendance
 
 </ol>
 
-<p>
-See also <a href="/people/representatives/warringah/tony_abbott/divisions">all votes</a>.
-</p>
+<a class="btn btn-default btn-sm" href="/people/representatives/warringah/tony_abbott/divisions">View all votes</a>
 </section>
 
 <section class="page-section" id="friends">
@@ -290,7 +288,7 @@ that were previously unsuspected. Or it may be nonsense.
 </tr>
 </tbody>
 </table>
-<a href="/people/representatives/warringah/tony_abbott/friends">More possible friends</a>
+<a class="btn btn-default btn-sm" href="/people/representatives/warringah/tony_abbott/friends">More possible friends</a>
 </section>
 
 </div>

--- a/spec/fixtures/static_pages/search.php?query=2088&button=Search.html
+++ b/spec/fixtures/static_pages/search.php?query=2088&button=Search.html
@@ -250,9 +250,7 @@ attendance
 
 </ol>
 
-<p>
-See also <a href="/people/representatives/warringah/tony_abbott/divisions">all votes</a>.
-</p>
+<a class="btn btn-default btn-sm" href="/people/representatives/warringah/tony_abbott/divisions">View all votes</a>
 </section>
 
 <section class="page-section" id="friends">
@@ -290,7 +288,7 @@ that were previously unsuspected. Or it may be nonsense.
 </tr>
 </tbody>
 </table>
-<a href="/people/representatives/warringah/tony_abbott/friends">More possible friends</a>
+<a class="btn btn-default btn-sm" href="/people/representatives/warringah/tony_abbott/friends">More possible friends</a>
 </section>
 
 </div>


### PR DESCRIPTION
This puts these two links in a consistent position and gives them a clean button style, establishing a consistent style for 'give me more like this' links.
## After

![screen shot 2014-10-29 at 4 20 24 pm](https://cloud.githubusercontent.com/assets/1239550/4821429/751a10d0-5f2c-11e4-9396-652c4d02058a.png)
## Before

![screen shot 2014-10-29 at 4 26 11 pm](https://cloud.githubusercontent.com/assets/1239550/4821430/7baee4ca-5f2c-11e4-84a0-f7a40691e9fe.png)

![screen shot 2014-10-29 at 4 26 15 pm](https://cloud.githubusercontent.com/assets/1239550/4821431/812232fe-5f2c-11e4-937e-559de51e6445.png)
