### PR TITLE
GitHub-style links to section headers on policy page (openaustralia/publicwhip#860)

### DIFF
--- a/app/assets/stylesheets/policies/_policy-voter-comparision.scss
+++ b/app/assets/stylesheets/policies/_policy-voter-comparision.scss
@@ -115,3 +115,18 @@
     padding: 14px  15px 0 0;
   }
 }
+
+.anchor {
+  position: absolute;
+  margin-left: -24px;
+  color: $text-color;
+  display: none;
+
+  :hover {
+    color: $text-color;
+  }
+}
+
+*:hover > .anchor {
+  display: block;
+}

--- a/app/views/policies/_policy_comparisons_block.html.haml
+++ b/app/views/policies/_policy_comparisons_block.html.haml
@@ -1,6 +1,8 @@
 - unless members.empty?
   .policy-comparision-block.row{class: "position-#{title.parameterize}"}
     %h3.policy-comparision-position.col-xs-12
+      %a.anchor{:id => title.parameterize, :href => "##{title.parameterize}" }
+        %span.fi-link
       = title
       = policy.name
     %ul.policy-comparision-list.list-unstyled.col-xs-12


### PR DESCRIPTION
Mousing-over the section heading and clicking the link icon that appears...
![image](https://cloud.githubusercontent.com/assets/103446/5422408/ded52caa-82ca-11e4-9b39-6341b39f43ba.png)

... updates the URL fragment:
![image](https://cloud.githubusercontent.com/assets/103446/5422414/2cc8511c-82cb-11e4-845a-8396c9ae1c5f.png)

I'm not sure if it's going to be obvious how this works for people that don't use GitHub. Maybe showing the link in a popover will be more usable, but I thought I'd try for a simpler solution first.
