### PR TITLE
Improve wrapping of the unsubscribe button for subscriptions list

### DIFF
--- a/app/assets/stylesheets/global/_subscriptions.scss
+++ b/app/assets/stylesheets/global/_subscriptions.scss
@@ -45,10 +45,23 @@
 
   .btn-unsubscribe {
     color: $gray-light;
+    float: right;
 
     &:hover,
     &:focus {
       color: $color-very-strongly-against;
+    }
+
+    @media (max-width: $screen-xs-max) {
+      span {
+        display: none;
+      }
+
+      i.fi-x {
+        font-size: 2em;
+        line-height: 1em;
+        vertical-align: top;
+      }
     }
   }
 }

--- a/app/views/users/subscriptions.html.haml
+++ b/app/views/users/subscriptions.html.haml
@@ -19,9 +19,11 @@
       %ul.subscriptions-list.object-list-compact.list-unstyled
         - @user.policies_watched.each do |policy|
           %li.object-item{id: "policy" + policy.id.to_s}
-            = link_to capitalise_initial_character(policy.name_with_for), policy
             = button_to watch_policy_path(policy), class: "btn btn-link btn-sm btn-unsubscribe", form_class: "object-secondary-inline" do
-              unsubscribe
+              %i.fi-x
+              %span
+                unsubscribe
+            = link_to capitalise_initial_character(policy.name_with_for), policy
     - else
       %p Get email alerts whenever the policies that interest you are updated or voted on. Subscribe on the policy’s page.
 


### PR DESCRIPTION
Possible fix for openaustralia/publicwhip#991.

Unsubscribe button stays floated to top-right instead of wrapping around, with a new small 'X' icon:
![image](https://cloud.githubusercontent.com/assets/103446/5422814/65a6b27c-82e3-11e4-8a1d-cf513d6cdef9.png)

On smaller screens, the 'unsubscribe' button switches to only the 'X' icon:
![image](https://cloud.githubusercontent.com/assets/103446/5422818/9d37520a-82e3-11e4-966a-f26b46b49449.png)
