### PR TITLE
Fix redirects if member is a senator

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -35,7 +35,11 @@ class MembersController < ApplicationController
       if params[:mpid]
         member = Member.find_by!(id: params[:mpid])
       elsif params[:id]
-        member = Member.find_by!(gid: params[:id])
+        member = begin
+                   Member.find_by!(gid: params[:id])
+                 rescue ActiveRecord::RecordNotFound
+                   Member.find_by!(gid: params[:id].gsub(/member/, 'lord'))
+                 end
       elsif params[:mpc] == "Senate" || params[:mpc].nil? || params[:house].nil?
         member = Member.with_name(params[:mpn].gsub("_", " "))
         member = member.in_house(params[:house]) if params[:house]

--- a/spec/requests/members_controller_spec.rb
+++ b/spec/requests/members_controller_spec.rb
@@ -57,6 +57,14 @@ describe MembersController, type: :request do
       end
 
       it { compare_static("/mp.php?mpn=Barnaby_Joyce&mpc=New_England&house=representatives") }
+
+      it "should redirect to the senator's page even if the id param incorrectly identifies a member as a senator and vice versa" do
+        # Barnaby has been set up above as a member and a senator.
+        # Let's refer to his senator record but incorrectly using `member` instead of `lord`
+        get "/mp.php?id=uk.org.publicwhip/member/100114"
+        expect(response.status).to eq 302
+        expect(response.headers["location"]).to eq "/mp.php?house=senate&mpc=Queensland&mpn=Barnaby_Joyce"
+      end
     end
 
     it "should 404 with an unknown person" do


### PR DESCRIPTION
See #1053 

- [x] Fix situation where the URL says `id=uk.org.publicwhip/member/100192` even though Member with id 100192 has `gid=uk.org.publicwhip/lord/100192`
- ~~Fix so that page renders at anchor `#divisions`~~
