### PR TITLE
Bundle update 2017 02 10 (CVE-2016-4442)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,11 +265,11 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-livereload (0.3.15)
       rack
-    rack-mini-profiler (0.9.2)
-      rack (>= 1.1.3)
+    rack-mini-profiler (0.10.2)
+      rack (>= 1.2.0)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     erubis (2.7.0)
     ethon (0.7.1)
       ffi (>= 1.3.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.9.1)
     execjs (2.6.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -506,4 +506,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.7


### PR DESCRIPTION
The eventmachine update I had to do locally to get it to bundle properly, so you may only want to cherry-pick 	f4c3780

Security fix is:

Version: 0.9.2
Advisory: CVE-2016-4442
Criticality: Unknown
URL: MiniProfiler/rack-mini-profiler@4273771
Title: rack-mini-profiler may disclose information to unauthorized users
Solution: upgrade to >= 0.10.1
