### PR TITLE
Refactor date validation on division_controller_spec

### DIFF
--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -27,19 +27,14 @@ class DivisionsController < ApplicationController
       @sort = params[:sort]
       @rdisplay = params[:rdisplay]
       @house = params[:house] unless params[:house] == "all"
-      if params[:date] =~ /^\d{4}$/
-        @year = params[:date]
-      elsif params[:date] =~/^\d{4}-\d{2}$/
-        @month = params[:date]
-      elsif params[:date]
-        begin
-          @date = Date.parse(params[:date])
-        rescue ArgumentError => e
-          render 'home/error_404', status: 404
-        end
+
+      begin
+        @date_start, @date_end, @date_range = DivisionParameterParser.get_date_range(params[:date]) if params[:date]
+        @date_start, @date_end, @date_range = DivisionParameterParser.get_date_range(@years.last.to_s) if @date_start.nil? && @date_end.nil? && @rdisplay.nil?
+      rescue ArgumentError => e
+        render 'home/error_404', status: 404
       end
-      # Set the year to the lastest we have data for if it's not set
-      @year = @years.last if @rdisplay.nil? && @date.nil? && @month.nil? && @year.nil?
+
       # This sets the parliament to display if it's not set. It's only here for legacy support
       # and should probably be cleaned up at some stage as we no longer focus on parliament sessions
       @rdisplay = "2013" if @rdisplay.nil?
@@ -77,10 +72,8 @@ class DivisionsController < ApplicationController
       @divisions = Division.order(order)
       @divisions = @divisions.joins(:division_info) if @sort == "rebellions" || @sort == "turnout"
       @divisions = @divisions.in_house(@house) if @house
-      @divisions = @divisions.on_date(@date) if @date
-      @divisions = @divisions.in_month(@month) if @month
-      @divisions = @divisions.in_year(@year) if @year
-      @divisions = @divisions.in_parliament(Parliament.all[@rdisplay]) unless @rdisplay == "all" || @date || @year
+      @divisions = @divisions.on_date_range(@date_start, @date_end) if @date_start && @date_end
+      @divisions = @divisions.in_parliament(Parliament.all[@rdisplay]) unless @rdisplay == "all" || @date_start || @date_end
       @divisions = @divisions.joins(:whips).where(whips: {party: @party}) if @party
       @divisions = @divisions.includes(:division_info, :wiki_motions, :whips)
     end

--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -31,7 +31,7 @@ class DivisionsController < ApplicationController
       begin
         @date_start, @date_end, @date_range = DivisionParameterParser.get_date_range(params[:date]) if params[:date]
         @date_start, @date_end, @date_range = DivisionParameterParser.get_date_range(@years.last.to_s) if @date_start.nil? && @date_end.nil? && @rdisplay.nil?
-      rescue ArgumentError => e
+      rescue ArgumentError
         render 'home/error_404', status: 404
       end
 
@@ -72,7 +72,7 @@ class DivisionsController < ApplicationController
       @divisions = Division.order(order)
       @divisions = @divisions.joins(:division_info) if @sort == "rebellions" || @sort == "turnout"
       @divisions = @divisions.in_house(@house) if @house
-      @divisions = @divisions.on_date_range(@date_start, @date_end) if @date_start && @date_end
+      @divisions = @divisions.in_date_range(@date_start, @date_end) if @date_start && @date_end
       @divisions = @divisions.in_parliament(Parliament.all[@rdisplay]) unless @rdisplay == "all" || @date_start || @date_end
       @divisions = @divisions.joins(:whips).where(whips: {party: @party}) if @party
       @divisions = @divisions.includes(:division_info, :wiki_motions, :whips)

--- a/app/helpers/divisions_helper.rb
+++ b/app/helpers/divisions_helper.rb
@@ -227,12 +227,15 @@ module DivisionsHelper
   end
 
   def divisions_period
-    if @year
-      @year
-    elsif @month
-      formatted_month(@month)
-    elsif @date
-      formatted_date(@date)
+    case @date_range
+    when :year
+      @date_start.year.to_s
+    when :month
+      @date_start.strftime("%B %Y")
+    when :day
+      formatted_date(@date_start)
+    else
+      raise ArgumentError, 'Not valid date'
     end
   end
 end

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -10,9 +10,7 @@ class Division < ActiveRecord::Base
 
   delegate :turnout, :aye_majority, :rebellions, :majority, :majority_fraction, to: :division_info
 
-  scope :on_date, ->(date) { where(date: date) }
-  scope :in_month, ->(month) { where("date >= ? AND date < ?", "#{month}-01", next_month(month)) }
-  scope :in_year, ->(year) { where("date >= ? AND date <= ?", "#{year}-01-01", "#{year}-12-31") }
+  scope :on_date_range, ->(date_start, date_end) { where("date >= ? AND date < ?", date_start, date_end) }
   scope :in_house, ->(house) { where(house: house) }
   scope :in_parliament, ->(parliament) { where("date >= ? AND date < ?", parliament[:from], parliament[:to]) }
   scope :possible_for_member, ->(member) { where(house: member.house).where("date >= ? AND date < ?", member.entered_house, member.left_house) }

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -10,7 +10,7 @@ class Division < ActiveRecord::Base
 
   delegate :turnout, :aye_majority, :rebellions, :majority, :majority_fraction, to: :division_info
 
-  scope :on_date_range, ->(date_start, date_end) { where("date >= ? AND date < ?", date_start, date_end) }
+  scope :in_date_range, ->(date_start, date_end) { where("date >= ? AND date < ?", date_start, date_end) }
   scope :in_house, ->(house) { where(house: house) }
   scope :in_parliament, ->(parliament) { where("date >= ? AND date < ?", parliament[:from], parliament[:to]) }
   scope :possible_for_member, ->(member) { where(house: member.house).where("date >= ? AND date < ?", member.entered_house, member.left_house) }

--- a/app/models/division_parameter_parser.rb
+++ b/app/models/division_parameter_parser.rb
@@ -1,0 +1,48 @@
+class DivisionParameterParser
+
+  YEAR_ONLY_REGEX = /^\d{4}$/
+  YEAR_AND_MONTH_REGEX = /^\d{4}-\d{1,2}$/
+  COMPLETE_DATE_REGEX = /^\d{4}-\d{1,2}-\d{1,2}$/
+
+  def self.get_date_range(date)
+
+    if date =~ YEAR_ONLY_REGEX
+      return get_year_range(date)
+    elsif date =~ YEAR_AND_MONTH_REGEX
+      return get_month_range(date)
+    elsif date =~ COMPLETE_DATE_REGEX
+      return get_day_range(date)
+    end
+
+    raise ArgumentError, 'Not a valid date format'
+  end
+
+private
+
+  def self.get_year_range(year)
+    date = Date.parse("#{year}-01-01")
+
+    return date, date + 1.year, :year
+  end
+
+  def self.get_month_range(partial_date)
+    date_parts = partial_date.split('-')
+    year = date_parts.first
+    month = date_parts.last
+
+    date = Date.parse("#{year}-#{month}-01")
+
+    return date, date + 1.month, :month
+  end
+
+  def self.get_day_range(complete_date)
+    date_parts = complete_date.split('-')
+    year = date_parts.first
+    month = date_parts[1]
+    day = date_parts.last
+
+    date = Date.parse("#{year}-#{month}-#{day}")
+
+    return date, date + 1.day, :day
+  end
+end

--- a/app/models/division_parameter_parser.rb
+++ b/app/models/division_parameter_parser.rb
@@ -1,20 +1,18 @@
 class DivisionParameterParser
-
   YEAR_ONLY_REGEX = /^\d{4}$/
   YEAR_AND_MONTH_REGEX = /^\d{4}-\d{1,2}$/
   COMPLETE_DATE_REGEX = /^\d{4}-\d{1,2}-\d{1,2}$/
 
   def self.get_date_range(date)
-
     if date =~ YEAR_ONLY_REGEX
       return get_year_range(date)
     elsif date =~ YEAR_AND_MONTH_REGEX
       return get_month_range(date)
     elsif date =~ COMPLETE_DATE_REGEX
       return get_day_range(date)
+    else
+      raise ArgumentError, 'Not a valid date format'
     end
-
-    raise ArgumentError, 'Not a valid date format'
   end
 
 private
@@ -26,21 +24,14 @@ private
   end
 
   def self.get_month_range(partial_date)
-    date_parts = partial_date.split('-')
-    year = date_parts.first
-    month = date_parts.last
-
+    year, month = partial_date.split('-')
     date = Date.parse("#{year}-#{month}-01")
 
     return date, date + 1.month, :month
   end
 
   def self.get_day_range(complete_date)
-    date_parts = complete_date.split('-')
-    year = date_parts.first
-    month = date_parts[1]
-    day = date_parts.last
-
+    year, month, day = complete_date.split('-')
     date = Date.parse("#{year}-#{month}-#{day}")
 
     return date, date + 1.day, :day

--- a/app/models/division_parameter_parser.rb
+++ b/app/models/division_parameter_parser.rb
@@ -5,11 +5,11 @@ class DivisionParameterParser
 
   def self.get_date_range(date)
     if date =~ YEAR_ONLY_REGEX
-      return get_year_range(date)
+      get_year_range(date)
     elsif date =~ YEAR_AND_MONTH_REGEX
-      return get_month_range(date)
+      get_month_range(date)
     elsif date =~ COMPLETE_DATE_REGEX
-      return get_day_range(date)
+      get_day_range(date)
     else
       raise ArgumentError, 'Not a valid date format'
     end

--- a/app/views/divisions/index.html.haml
+++ b/app/views/divisions/index.html.haml
@@ -11,7 +11,7 @@
     .page-header.container
       %h1
         = yield :title
-        - if @year || @month || @date
+        - if @date_start || @date_end
           %small= divisions_period
         - elsif @rdisplay != "all"
           %small= Parliament.all[@rdisplay][:name]
@@ -30,4 +30,4 @@
 %nav.index-pagination
   %ul.pagination
     - @years.reverse.each do |year|
-      = nav_link(year, {date: year, house: (@house.nil? ? "all" : @house)}, "Divisions held in #{year}", (@year.to_i == year))
+      = nav_link(year, {date: year, house: (@house.nil? ? "all" : @house)}, "Divisions held in #{year}", (@date_start && @date_start.year == year))

--- a/spec/controllers/divisions_controller_spec.rb
+++ b/spec/controllers/divisions_controller_spec.rb
@@ -28,7 +28,7 @@ describe DivisionsController, :type => :controller do
       end
     end
 
-    context "when request has an date parameter with an incorret format" do
+    context "when request has an date parameter with an incorrect format" do
       it "should return generic 404 page" do
         get :index, date: '2017-12-222', house: "representatives"
 

--- a/spec/controllers/divisions_controller_spec.rb
+++ b/spec/controllers/divisions_controller_spec.rb
@@ -21,7 +21,16 @@ describe DivisionsController, :type => :controller do
 
     context "when request has an invalid date as a parameter" do
       it "should return generic 404 page" do
-        get :index, date: '2017-02-0222', house: "representatives"
+        get :index, date: '2017-13-22', house: "representatives"
+
+        expect(response).to render_template "home/error_404"
+        expect(response.status).to be 404
+      end
+    end
+
+    context "when request has an date parameter with an incorret format" do
+      it "should return generic 404 page" do
+        get :index, date: '2017-12-222', house: "representatives"
 
         expect(response).to render_template "home/error_404"
         expect(response.status).to be 404
@@ -72,7 +81,7 @@ describe DivisionsController, :type => :controller do
       end
     end
 
-    context "when the date parameter is just a year and a month (YYY-MM)" do
+    context "when the date parameter is just a year and a month (YYYY-MM)" do
       context "and date matches divisions already stored" do
         it "should render index template with selected divisions" do
           get :index, date: '2016-12', house: "representatives"

--- a/spec/helpers/divisions_helper_spec.rb
+++ b/spec/helpers/divisions_helper_spec.rb
@@ -36,7 +36,8 @@ describe DivisionsHelper, type: :helper do
   describe "#divisions_period" do
     context "year specified" do
       before do
-        helper.instance_variable_set("@year", "2014")
+        helper.instance_variable_set("@date_range", :year)
+        helper.instance_variable_set("@date_start", Date.parse('2014-01-01'))
       end
 
       it "returns year when present" do
@@ -46,7 +47,8 @@ describe DivisionsHelper, type: :helper do
 
     context "month specified" do
       before do
-        helper.instance_variable_set("@month", "2014-06")
+        helper.instance_variable_set("@date_range", :month)
+        helper.instance_variable_set("@date_start", Date.parse('2014-06-01'))
       end
 
       it "returns formatted month when present" do
@@ -56,7 +58,8 @@ describe DivisionsHelper, type: :helper do
 
     context "date specified" do
       before do
-        helper.instance_variable_set("@date", Date.parse("2014-06-01"))
+        helper.instance_variable_set("@date_range", :day)
+        helper.instance_variable_set("@date_start", Date.parse('2014-06-01'))
       end
 
       it "returns formatted date when present" do

--- a/spec/models/division_parameter_parser_spec.rb
+++ b/spec/models/division_parameter_parser_spec.rb
@@ -1,39 +1,37 @@
 require 'spec_helper'
 
 describe DivisionParameterParser, type: :model do
-  describe '::get_date_range' do
-    it 'gets range for complete date\'s format' do
+  describe ".get_date_range" do
+    it "gets range for complete date's format" do
       date_start, date_end, date_range = DivisionParameterParser.get_date_range('2017-12-20')
 
-      expect(date_start).to eq(Date.parse('2017-12-20'))
-      expect(date_end).to eq(Date.parse('2017-12-21'))
+      expect(date_start).to eq(Date.new(2017, 12, 20))
+      expect(date_end).to eq(Date.new(2017, 12, 21))
       expect(date_range).to eq(:day)
     end
 
-    it 'gets range for year and month date\'s format' do
+    it "gets range for year and month date's format" do
       date_start, date_end, date_range = DivisionParameterParser.get_date_range('2017-12')
 
-      expect(date_start).to eq(Date.parse('2017-12-01'))
-      expect(date_end).to eq(Date.parse('2018-01-01'))
+      expect(date_start).to eq(Date.new(2017, 12, 01))
+      expect(date_end).to eq(Date.new(2018, 01, 01))
       expect(date_range).to eq(:month)
     end
 
-    it 'gets range for year only date\'s format' do
+    it "gets range for year only date's format" do
       date_start, date_end, date_range = DivisionParameterParser.get_date_range('2017')
 
-      expect(date_start).to eq(Date.parse('2017-01-01'))
-      expect(date_end).to eq(Date.parse('2018-01-01'))
+      expect(date_start).to eq(Date.new(2017, 01, 01))
+      expect(date_end).to eq(Date.new(2018, 01, 01))
       expect(date_range).to eq(:year)
     end
 
-    it 'raise exception for invalid date' do
+    it "raise exception for invalid date" do
       expect { DivisionParameterParser.get_date_range('2017-13-01') }.to raise_error(ArgumentError)
     end
 
-    it 'raise exception for date in the wrong format' do
+    it "raise exception for date in the wrong format" do
       expect { DivisionParameterParser.get_date_range('2017-12-011') }.to raise_error(ArgumentError)
     end
-
   end
-
 end

--- a/spec/models/division_parameter_parser_spec.rb
+++ b/spec/models/division_parameter_parser_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe DivisionParameterParser, type: :model do
+  describe '::get_date_range' do
+    it 'gets range for complete date\'s format' do
+      date_start, date_end, date_range = DivisionParameterParser.get_date_range('2017-12-20')
+
+      expect(date_start).to eq(Date.parse('2017-12-20'))
+      expect(date_end).to eq(Date.parse('2017-12-21'))
+      expect(date_range).to eq(:day)
+    end
+
+    it 'gets range for year and month date\'s format' do
+      date_start, date_end, date_range = DivisionParameterParser.get_date_range('2017-12')
+
+      expect(date_start).to eq(Date.parse('2017-12-01'))
+      expect(date_end).to eq(Date.parse('2018-01-01'))
+      expect(date_range).to eq(:month)
+    end
+
+    it 'gets range for year only date\'s format' do
+      date_start, date_end, date_range = DivisionParameterParser.get_date_range('2017')
+
+      expect(date_start).to eq(Date.parse('2017-01-01'))
+      expect(date_end).to eq(Date.parse('2018-01-01'))
+      expect(date_range).to eq(:year)
+    end
+
+    it 'raise exception for invalid date' do
+      expect { DivisionParameterParser.get_date_range('2017-13-01') }.to raise_error(ArgumentError)
+    end
+
+    it 'raise exception for date in the wrong format' do
+      expect { DivisionParameterParser.get_date_range('2017-12-011') }.to raise_error(ArgumentError)
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is to finish the work around date validation on the divisions controller page I have started in January. Now it always returns 404 if date is invalid (i.e. 2017-13-12) or date has a bad format (i.e. 2017-111-20). 

I also make an extra effort to make sure the tests comparing the generated pages with the legacy php pages at `spec/requests/divisions_controller_spec.rb` didn't break. Not sure how important is to keep this compatibility, but for now it seems to work good. 