### PR TITLE
Fixed bug in people page

### DIFF
--- a/app/views/divisions/index_with_member.html.haml
+++ b/app/views/divisions/index_with_member.html.haml
@@ -9,5 +9,4 @@
 
 %p All votes #{@member.full_name_no_electorate} could have attended.
 
-- @member.person.members.order(entered_house: :desc).each do |member|
-  = render "divisions", member: @member, divisions: member.divisions_possible.order(date: :desc, clock_time: :desc, name: :asc)
+= render "divisions", member: @member, divisions: @member.divisions_possible.order(date: :desc, clock_time: :desc, name: :asc)


### PR DESCRIPTION
Fixed bug in people page. It will only load one person per member page. Resolves #1124 