### PR TITLE
Fix the issue https://github.com/openaustralia/publicwhip/issues/1078

### DIFF
--- a/app/assets/stylesheets/members/_member-show.scss
+++ b/app/assets/stylesheets/members/_member-show.scss
@@ -26,7 +26,7 @@
 
   .media .pull-left {
     padding: 0;
-    margin-right: 15px;
+    margin-right: 10px;
   }
 
   .object-data-rebellion small,

--- a/app/views/home/history.html.haml
+++ b/app/views/home/history.html.haml
@@ -2,5 +2,4 @@
 - set_meta_tags description: "Recent edits to divisions and policies by the #{Settings.project_name} community."
 .page-header
   %h1 All edits made in the last week
-
 = render partial: "layouts/history_list"


### PR DESCRIPTION
This pull request aims to fix the issue #1078
The space to the right of the members photo is wider by 5px on the member show page than the divisions index with member page. So, the space has been made same on both the pages.