### PR TITLE
Member header layouts made same for pages

### DIFF
--- a/app/assets/stylesheets/members/_member-show.scss
+++ b/app/assets/stylesheets/members/_member-show.scss
@@ -26,7 +26,7 @@
 
   .media .pull-left {
     padding: 0;
-    margin-right: 15px;
+    margin-right: 10px;
   }
 
   .object-data-rebellion small,


### PR DESCRIPTION
This pull request aims to fix the issue https://github.com/openaustralia/publicwhip/issues/1078
Toggling between the member show and the divisions page, it is seen that the space to the right of the members photo is wider on the member show page than the divisions index with member page.
The divisions page has a difference of 10px whereas the member show page has a difference of 15px. 
To maintain consistency and considering that a 10px difference is more appropriate, the 15px difference on the member show page has been changed to 10px.