### PR TITLE
Recent Changes page header layout changed

### DIFF
--- a/app/views/home/history.html.haml
+++ b/app/views/home/history.html.haml
@@ -1,6 +1,8 @@
 - content_for :title, 'Recent edits'
 - set_meta_tags description: "Recent edits to divisions and policies by the #{Settings.project_name} community."
-.page-header
-  %h1 All edits made in the last week
+- content_for :header do
+  .section-header.clearfix
+    .page-header.container
+      %h1 All edits made in the last week
 
 = render partial: "layouts/history_list"


### PR DESCRIPTION
Fixes #989.

The Recent Changes page https://theyvoteforyou.org.au/history contained two lines below the header, the upper one coming from it as it was a page-header, and the lower one coming from the list of recent changes.
The upper line looked unnecessary, so it was removed. 
Also, to make the design consistent with the other pages layout, the header layout was changed and made similar to other pages like https://theyvoteforyou.org.au/help/faq.
In this commit, the Recent Changes page does not contain the unnecessary line and also has a consistent (similar to other pages) header layout.

This is how the Recent Changes page now looks like (in the commit).
![testing](https://cloud.githubusercontent.com/assets/16884926/24392175/5ebbfc46-13b0-11e7-9f05-533d9ca228f5.png)
