### PR TITLE
Adding Generic 404 page error

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module Publicwhip
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.exceptions_app = self.routes
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.


### PR DESCRIPTION
adding the line;

config.exceptions_app = self.routes in (config/application.rb) to tell the application's router to handle the errors. If the URL is missing or misspelled then it should redirect to the 404 page.
