### PR TITLE
Remove padding from introductory paragraph on MP votes on policy page

### DIFF
--- a/app/assets/stylesheets/policies/_policy-voter-comparision.scss
+++ b/app/assets/stylesheets/policies/_policy-voter-comparision.scss
@@ -130,3 +130,7 @@
 *:hover > .anchor {
   display: block;
 }
+
+#col-sm-fixup {
+  padding-left: 0;
+}

--- a/app/assets/stylesheets/policies/_policy-voter-comparision.scss
+++ b/app/assets/stylesheets/policies/_policy-voter-comparision.scss
@@ -131,6 +131,6 @@
   display: block;
 }
 
-#col-sm-fixup {
+#voting-comparision {
   padding-left: 0;
 }

--- a/app/views/policies/show_with_member.html.haml
+++ b/app/views/policies/show_with_member.html.haml
@@ -16,7 +16,7 @@
 
 = render "social_share"
 
-%p#col-sm-fixup.col-sm-7
+%p#voting-comparision.col-sm-7
   How
   = link_to @member.name, @member
   voted compared to someone who believes that

--- a/app/views/policies/show_with_member.html.haml
+++ b/app/views/policies/show_with_member.html.haml
@@ -16,7 +16,7 @@
 
 = render "social_share"
 
-%p.col-sm-7
+%p#col-sm-fixup.col-sm-7
   How
   = link_to @member.name, @member
   voted compared to someone who believes that

--- a/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&dmp=1.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&dmp=1.html
@@ -89,7 +89,7 @@ Twitter
 </ul>
 </aside>
 
-<p class="col-sm-7">
+<p class="col-sm-7" id="col-sm-fixup">
 How
 <a href="/people/senate/tasmania/christine_milne">Christine Milne</a>
 voted compared to someone who believes that

--- a/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&dmp=1.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&dmp=1.html
@@ -89,7 +89,7 @@ Twitter
 </ul>
 </aside>
 
-<p class="col-sm-7" id="col-sm-fixup">
+<p class="col-sm-7" id="voting-comparision">
 How
 <a href="/people/senate/tasmania/christine_milne">Christine Milne</a>
 voted compared to someone who believes that

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&dmp=1.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&dmp=1.html
@@ -89,7 +89,7 @@ Twitter
 </ul>
 </aside>
 
-<p class="col-sm-7">
+<p class="col-sm-7" id="col-sm-fixup">
 How
 <a href="/people/representatives/griffith/kevin_rudd">Kevin Rudd</a>
 voted compared to someone who believes that

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&dmp=1.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&dmp=1.html
@@ -89,7 +89,7 @@ Twitter
 </ul>
 </aside>
 
-<p class="col-sm-7" id="col-sm-fixup">
+<p class="col-sm-7" id="voting-comparision">
 How
 <a href="/people/representatives/griffith/kevin_rudd">Kevin Rudd</a>
 voted compared to someone who believes that

--- a/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&dmp=1.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&dmp=1.html
@@ -89,7 +89,7 @@ Twitter
 </ul>
 </aside>
 
-<p class="col-sm-7" id="col-sm-fixup">
+<p class="col-sm-7" id="voting-comparision">
 How
 <a href="/people/representatives/warringah/tony_abbott">Tony Abbott</a>
 voted compared to someone who believes that

--- a/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&dmp=1.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&dmp=1.html
@@ -89,7 +89,7 @@ Twitter
 </ul>
 </aside>
 
-<p class="col-sm-7">
+<p class="col-sm-7" id="col-sm-fixup">
 How
 <a href="/people/representatives/warringah/tony_abbott">Tony Abbott</a>
 voted compared to someone who believes that


### PR DESCRIPTION
This commit aims to fix the issue #1095
The MP votes on policy page has a problem with the vertical alignment as mentioned in the issue. The introductory paragraph does not align vertically with the other part of the page, it is shifted to the right because of the use of col-sm-7 class of Bootstrap, which introduces a padding of 15px.
To override this, a new id is added to this paragraph with the left padding made 0, to shift it to the right position.

Now, it looks like
![fixedupstuff](https://cloud.githubusercontent.com/assets/16884926/24450177/8e159758-1497-11e7-9a11-61757677c987.jpg)

Closes #1095