### PR TITLE
Use present tense for former member rebellions

### DIFF
--- a/app/views/members/_member_page_header.html.haml
+++ b/app/views/members/_member_page_header.html.haml
@@ -13,17 +13,30 @@
           %p.member-data.object-data
             - if member.person.rebellions_fraction
               %span.member-rebellions.object-data-rebellion
-                -if member.person.rebellions_fraction == 0
-                  Never rebels
-                -else
-                  -# TODO: Should this be an absolute count rather than percentage?
-                  -# Maybe it's good to show it as a percentage because it highlights rarity?
-                  Rebels
-                  = fraction_to_percentage_display(member.person.rebellions_fraction)
-                  of the time
-                  -# TODO: add helper tooltip for rebellions
-                  -# link_to "explain...", help_faq_path(anchor: "clarify")
+                - if !member.currently_in_parliament?
+                  - if member.person.rebellions_fraction == 0
+                    Never rebelled
+                  - else
+                    -# TODO: Should this be an absolute count rather than percentage?
+                    -# Maybe it's good to show it as a percentage because it highlights rarity?
+                    Rebelled
+                    = fraction_to_percentage_display(member.person.rebellions_fraction)
+                    of the time
+                    -# TODO: add helper tooltip for rebellions
+                    -# link_to "explain...", help_faq_path(anchor: "clarify")
+                - else
+                  - if member.person.rebellions_fraction == 0
+                    Never rebels
+                  - else
+                    -# TODO: Should this be an absolute count rather than percentage?
+                    -# Maybe it's good to show it as a percentage because it highlights rarity?
+                    Rebels
+                    = fraction_to_percentage_display(member.person.rebellions_fraction)
+                    of the time
+                    -# TODO: add helper tooltip for rebellions
+                    -# link_to "explain...", help_faq_path(anchor: "clarify")
                 %small= link_to "explain rebellions", help_faq_path(anchor: "rebellion")
+               
             - if member.person.attendance_fraction
               %span.member-attendance.object-data-attendance
                 = fraction_to_percentage_display(member.person.attendance_fraction)
@@ -36,4 +49,4 @@
     .header-secondary-primary-block
       = link_to "Speeches in Parliament", "http://www.openaustralia.org.au/mp/?m=#{member.id}", class: "member-speeches-link btn btn-sm btn-link btn-lone-link"
 
-    = render "social_share"
+    = render "social_share" 

--- a/app/views/members/_member_page_header.html.haml
+++ b/app/views/members/_member_page_header.html.haml
@@ -13,30 +13,19 @@
           %p.member-data.object-data
             - if member.person.rebellions_fraction
               %span.member-rebellions.object-data-rebellion
-                - if !member.currently_in_parliament?
-                  - if member.person.rebellions_fraction == 0
-                    Never rebelled
-                  - else
-                    -# TODO: Should this be an absolute count rather than percentage?
-                    -# Maybe it's good to show it as a percentage because it highlights rarity?
-                    Rebelled
-                    = fraction_to_percentage_display(member.person.rebellions_fraction)
-                    of the time
-                    -# TODO: add helper tooltip for rebellions
-                    -# link_to "explain...", help_faq_path(anchor: "clarify")
-                - else
-                  - if member.person.rebellions_fraction == 0
-                    Never rebels
-                  - else
-                    -# TODO: Should this be an absolute count rather than percentage?
-                    -# Maybe it's good to show it as a percentage because it highlights rarity?
-                    Rebels
-                    = fraction_to_percentage_display(member.person.rebellions_fraction)
-                    of the time
-                    -# TODO: add helper tooltip for rebellions
-                    -# link_to "explain...", help_faq_path(anchor: "clarify")
+                -if member.person.rebellions_fraction == 0
+                  = "Never Rebels" if member.currently_in_parliament?
+                  = "Never Rebelled" if !member.currently_in_parliament?
+                -else
+                  -# TODO: Should this be an absolute count rather than percentage?
+                  -# Maybe it's good to show it as a percentage because it highlights rarity?
+                  = "Rebels" if member.currently_in_parliament?
+                  = "Rebelled" if !member.currently_in_parliament?   
+                  = fraction_to_percentage_display(member.person.rebellions_fraction)
+                  of the time
+                  -# TODO: add helper tooltip for rebellions
+                  -# link_to "explain...", help_faq_path(anchor: "clarify")
                 %small= link_to "explain rebellions", help_faq_path(anchor: "rebellion")
-               
             - if member.person.attendance_fraction
               %span.member-attendance.object-data-attendance
                 = fraction_to_percentage_display(member.person.attendance_fraction)


### PR DESCRIPTION
This pull request aims to fix the issue https://github.com/openaustralia/publicwhip/issues/726
Initially, on the Member Show page, 'Rebels' was used for current and former members as well. For former members, it should be 'Rebelled' instead.
After this commit, 'Rebels' would be used for current members and 'Rebelled' for former members.

Now, it looks like: 
![newupload](https://cloud.githubusercontent.com/assets/16884926/24507143/4e39b0e2-157d-11e7-81d4-7ef26c9ff133.png)
