### PR TITLE
Use past tense for former member rebellions

### DIFF
--- a/app/views/members/_member_page_header.html.haml
+++ b/app/views/members/_member_page_header.html.haml
@@ -14,11 +14,13 @@
             - if member.person.rebellions_fraction
               %span.member-rebellions.object-data-rebellion
                 -if member.person.rebellions_fraction == 0
-                  Never rebels
+                  = "Never rebels" if member.currently_in_parliament?
+                  = "Never rebelled" if !member.currently_in_parliament?
                 -else
                   -# TODO: Should this be an absolute count rather than percentage?
                   -# Maybe it's good to show it as a percentage because it highlights rarity?
-                  Rebels
+                  = "Rebels" if member.currently_in_parliament?
+                  = "Rebelled" if !member.currently_in_parliament?
                   = fraction_to_percentage_display(member.person.rebellions_fraction)
                   of the time
                   -# TODO: add helper tooltip for rebellions

--- a/app/views/members/_member_page_header.html.haml
+++ b/app/views/members/_member_page_header.html.haml
@@ -14,13 +14,11 @@
             - if member.person.rebellions_fraction
               %span.member-rebellions.object-data-rebellion
                 -if member.person.rebellions_fraction == 0
-                  = "Never rebels" if member.currently_in_parliament?
-                  = "Never rebelled" if !member.currently_in_parliament?
+                  = member.currently_in_parliament? ? "Never rebels" : "Never rebelled"
                 -else
                   -# TODO: Should this be an absolute count rather than percentage?
                   -# Maybe it's good to show it as a percentage because it highlights rarity?
-                  = "Rebels" if member.currently_in_parliament?
-                  = "Rebelled" if !member.currently_in_parliament?
+                  = member.currently_in_parliament? ? "Rebels" : "Rebelled"
                   = fraction_to_percentage_display(member.person.rebellions_fraction)
                   of the time
                   -# TODO: add helper tooltip for rebellions

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=allfriends.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=allfriends.html
@@ -69,7 +69,8 @@ Submit
 <p class="member-role lead"><span class="title">Former Australian Labor Party Representative for <span class="electorate">Griffith</span></span> <span class="member-period">October 1998 – November 2013</span></p>
 <p class="member-data object-data">
 <span class="member-rebellions object-data-rebellion">
-Never rebels
+
+Never rebelled
 <small><a href="/help/faq#rebellion">explain rebellions</a></small>
 </span>
 <span class="member-attendance object-data-attendance">

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=everyvote.html
@@ -69,7 +69,8 @@ Submit
 <p class="member-role lead"><span class="title">Former Australian Labor Party Representative for <span class="electorate">Griffith</span></span> <span class="member-period">October 1998 – November 2013</span></p>
 <p class="member-data object-data">
 <span class="member-rebellions object-data-rebellion">
-Never rebels
+
+Never rebelled
 <small><a href="/help/faq#rebellion">explain rebellions</a></small>
 </span>
 <span class="member-attendance object-data-attendance">

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives.html
@@ -79,7 +79,8 @@ Submit
 <p class="member-role lead"><span class="title">Former Australian Labor Party Representative for <span class="electorate">Griffith</span></span> <span class="member-period">October 1998 – November 2013</span></p>
 <p class="member-data object-data">
 <span class="member-rebellions object-data-rebellion">
-Never rebels
+
+Never rebelled
 <small><a href="/help/faq#rebellion">explain rebellions</a></small>
 </span>
 <span class="member-attendance object-data-attendance">

--- a/spec/fixtures/static_pages/mp.php?mpn=Roger_Price&mpc=Chifley&house=representatives.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Roger_Price&mpc=Chifley&house=representatives.html
@@ -79,7 +79,8 @@ Submit
 <p class="member-role lead"><span class="title">Former Australian Labor Party Representative for <span class="electorate">Chifley</span></span> <span class="member-period">December 1984 – August 2010</span></p>
 <p class="member-data object-data">
 <span class="member-rebellions object-data-rebellion">
-Never rebels
+
+Never rebelled
 <small><a href="/help/faq#rebellion">explain rebellions</a></small>
 </span>
 <span class="member-attendance object-data-attendance">


### PR DESCRIPTION
This commit aims to fix the issue openaustralia#726
Initially, on the Member Show page, 'Rebels' was used for current and former members as well. For former members, it should be 'Rebelled' instead.
After this commit, 'Rebels' would be used for current members and 'Rebelled' for former members.

For former members, it looks like :
![newupload](https://cloud.githubusercontent.com/assets/16884926/24550455/bb44de6e-163b-11e7-9c67-47930dbde801.png)
