### PR TITLE
When users log out redirect them to the home page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,6 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(resource)
-    request.referer ? URI.parse(request.referer).path : root_path
+    root_path 'home#index'
   end
 end


### PR DESCRIPTION
This pull request aims to fix issue #1076.
Currently when a user logs out you get taken to the sign in page and told to sign back in and then you  get taken back to that same page.I think this is because we have set the session to previous URL. I suggest that once users click log out they should be redirected to the home page.