### PR TITLE
Extracting logic from view and adding it to helpers

### DIFF
--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -59,14 +59,13 @@ module MembersHelper
     text.html_safe + "."
   end
 
-  def member_rebellion(member)
+  def member_rebellion_record_sentence(member)
     if member.person.rebellions_fraction == 0
-      text = member.currently_in_parliament? ? "Never rebels" : "Never rebelled"
+      member.currently_in_parliament? ? "Never rebels" : "Never rebelled"
     else
       # TODO: Should this be an absolute count rather than percentage?
       # Maybe it's good to show it as a percentage because it highlights rarity?
-      text = (member.currently_in_parliament? ? "Rebels " : "Rebelled ") + fraction_to_percentage_display(member.person.rebellions_fraction) + " of the time"
+      (member.currently_in_parliament? ? "Rebels " : "Rebelled ") + fraction_to_percentage_display(member.person.rebellions_fraction) + " of the time"
     end
-    text
   end
 end

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -58,4 +58,15 @@ module MembersHelper
     end.to_sentence
     text.html_safe + "."
   end
+
+  def member_rebellion(member)
+    if member.person.rebellions_fraction == 0
+      text = member.currently_in_parliament? ? "Never rebels" : "Never rebelled"
+    else
+      # TODO: Should this be an absolute count rather than percentage?
+      # Maybe it's good to show it as a percentage because it highlights rarity?
+      text = (member.currently_in_parliament? ? "Rebels " : "Rebelled ") + fraction_to_percentage_display(member.person.rebellions_fraction) + " of the time"
+    end
+    text
+  end
 end

--- a/app/views/members/_member_page_header.html.haml
+++ b/app/views/members/_member_page_header.html.haml
@@ -13,16 +13,9 @@
           %p.member-data.object-data
             - if member.person.rebellions_fraction
               %span.member-rebellions.object-data-rebellion
-                -if member.person.rebellions_fraction == 0
-                  = member.currently_in_parliament? ? "Never rebels" : "Never rebelled"
-                -else
-                  -# TODO: Should this be an absolute count rather than percentage?
-                  -# Maybe it's good to show it as a percentage because it highlights rarity?
-                  = member.currently_in_parliament? ? "Rebels" : "Rebelled"
-                  = fraction_to_percentage_display(member.person.rebellions_fraction)
-                  of the time
-                  -# TODO: add helper tooltip for rebellions
-                  -# link_to "explain...", help_faq_path(anchor: "clarify")
+                #{member_rebellion(member)}
+                -# TODO: add helper tooltip for rebellions
+                -# link_to "explain...", help_faq_path(anchor: "clarify")
                 %small= link_to "explain rebellions", help_faq_path(anchor: "rebellion")
             - if member.person.attendance_fraction
               %span.member-attendance.object-data-attendance

--- a/app/views/members/_member_page_header.html.haml
+++ b/app/views/members/_member_page_header.html.haml
@@ -13,7 +13,7 @@
           %p.member-data.object-data
             - if member.person.rebellions_fraction
               %span.member-rebellions.object-data-rebellion
-                #{member_rebellion(member)}
+                = member_rebellion_record_sentence(member)
                 -# TODO: add helper tooltip for rebellions
                 -# link_to "explain...", help_faq_path(anchor: "clarify")
                 %small= link_to "explain rebellions", help_faq_path(anchor: "rebellion")

--- a/spec/helpers/members_helper_spec.rb
+++ b/spec/helpers/members_helper_spec.rb
@@ -1,5 +1,37 @@
 require 'spec_helper'
 
 describe MembersHelper, type: :helper do
+  describe "#member_rebellion_record_sentence" do
+    context "Former member who not has rebelled" do
+      let(:member) do
+        mock_model Member, :person => mock_model(Person, rebellions_fraction: 0),
+                           :currently_in_parliament? => false
+      end
+      it { expect(helper.member_rebellion_record_sentence(member)).to eq "Never rebelled" }
+    end
 
+    context "Current member who does not rebel" do
+      let(:member) do
+        mock_model Member, :person => mock_model(Person, rebellions_fraction: 0),
+                           :currently_in_parliament? => true
+      end
+      it { expect(helper.member_rebellion_record_sentence(member)).to eq "Never rebels" }
+    end
+
+    context "Former member who has rebelled" do
+      let(:member) do
+        mock_model Member, :person => mock_model(Person, rebellions_fraction: 0.5),
+                           :currently_in_parliament? => false
+      end
+      it { expect(helper.member_rebellion_record_sentence(member)).to eq "Rebelled 50% of the time" }
+    end
+
+    context "Current member who rebels" do
+      let(:member) do
+        mock_model Member, :person => mock_model(Person, rebellions_fraction: 0.5),
+                           :currently_in_parliament? => true
+      end
+      it { expect(helper.member_rebellion_record_sentence(member)).to eq "Rebels 50% of the time" }
+    end
+  end
 end


### PR DESCRIPTION
The logic for member rebellion (whether it should be Rebelled/Rebels/Never rebels/Never rebelled) in the member page header file was complicated and hence was moved to view helpers to make it look simple and consistent.
