### PR TITLE
config: fix NoMethodError

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Publicwhip::Application.routes.draw do
     constraints: lambda {|r| r.query_parameters["mpid"] || r.query_parameters["id"]}
   get 'mp.php' => 'electorates#show_redirect',
     constraints: lambda {|r| r.query_parameters["mpn"].nil? && (r.query_parameters["display"] || r.query_parameters["dmp"] || r.query_parameters["house"].nil?)}
-  get 'mp.php' => redirect{|p,r| "/members/#{r.query_parameters['house']}/#{r.query_parameters['mpc'].downcase.gsub(' ', '_')}"},
+  get 'mp.php' => redirect{|p,r| "/members/#{r.query_parameters['house']}/#{r.query_parameters['mpc'].to_s.downcase.gsub(' ', '_')}"},
     constraints: lambda {|r| r.query_parameters["mpn"].nil?}
   get 'mp.php' => 'members#show_redirect',
     constraints: lambda {|r| r.query_parameters["dmp"] && r.query_parameters["display"] == "allvotes"}


### PR DESCRIPTION
fixes NoMethodError for nil:NilClass on line 34 
'undefine method for nil:NilClass' means the method is being called on
 a `nil` value. Incorporating the `.to_s` method makes `nil.to_s` an 
empty string by default, hence fixing the issue.

Closes: #1064 