### PR TITLE
Avoided multiple render methods to be called at DivisionsController

### DIFF
--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -21,13 +21,16 @@ class DivisionsController < ApplicationController
         @date_start, @date_end, @date_range = get_date_range(params[:date])
       rescue ArgumentError
         render 'home/error_404', status: 404
+        return
       end
 
       if @member
         @divisions = @member.divisions_they_could_have_attended_between(@date_start, @date_end)
         render 'index_with_member'
+        return
       else
         render 'members/member_not_found', status: 404
+        return
       end
     else
       @sort = params[:sort]
@@ -38,6 +41,7 @@ class DivisionsController < ApplicationController
         @date_start, @date_end, @date_range = get_date_range(params[:date], @rdisplay)
       rescue ArgumentError
         render 'home/error_404', status: 404
+        return
       end
 
       # This sets the parliament to display if it's not set. It's only here for legacy support

--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -20,17 +20,14 @@ class DivisionsController < ApplicationController
       begin
         @date_start, @date_end, @date_range = get_date_range(params[:date])
       rescue ArgumentError
-        render 'home/error_404', status: 404
-        return
+        return render 'home/error_404', status: 404
       end
 
       if @member
         @divisions = @member.divisions_they_could_have_attended_between(@date_start, @date_end)
-        render 'index_with_member'
-        return
+        return render 'index_with_member'
       else
-        render 'members/member_not_found', status: 404
-        return
+        return render 'members/member_not_found', status: 404
       end
     else
       @sort = params[:sort]
@@ -40,8 +37,7 @@ class DivisionsController < ApplicationController
       begin
         @date_start, @date_end, @date_range = get_date_range(params[:date], @rdisplay)
       rescue ArgumentError
-        render 'home/error_404', status: 404
-        return
+        return render 'home/error_404', status: 404
       end
 
       # This sets the parliament to display if it's not set. It's only here for legacy support

--- a/spec/controllers/divisions_controller_spec.rb
+++ b/spec/controllers/divisions_controller_spec.rb
@@ -124,16 +124,27 @@ describe DivisionsController, :type => :controller do
       end
 
       context "and a date is specified" do
-        it "should get votes based on the date specified" do
-          get :index, mpc: "newtown", mpn: "christine_milne", house: "representatives", date: "2013"
+        context "and date is valid" do
+          it "should get votes based on the date specified" do
+            get :index, mpc: "newtown", mpn: "christine_milne", house: "representatives", date: "2013"
 
-          expect(response).to render_template "divisions/index_with_member"
-          expect(response.status).to be 200
-          expect(assigns(:member)).to eq(representative)
-          expect(assigns(:date_start)).to eq(Date.new(2013, 01, 01))
-          expect(assigns(:date_end)).to eq(Date.new(2014, 01, 01))
-          expect(assigns(:date_range)).to eq(:year)
-          expect(assigns(:divisions)).to eq([older_division])
+            expect(response).to render_template "divisions/index_with_member"
+            expect(response.status).to be 200
+            expect(assigns(:member)).to eq(representative)
+            expect(assigns(:date_start)).to eq(Date.new(2013, 01, 01))
+            expect(assigns(:date_end)).to eq(Date.new(2014, 01, 01))
+            expect(assigns(:date_range)).to eq(:year)
+            expect(assigns(:divisions)).to eq([older_division])
+          end
+        end
+
+        context "and date is not valid" do
+          it "should return generic 404 page" do
+            get :index, mpc: "newtown", mpn: "christine_milne", house: "representatives", date: "2013-15-15"
+
+            expect(response).to render_template "home/error_404"
+            expect(response.status).to be 404
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #1148 

The issue was that the `render` method does stop prevent further actions to continue, so depending on the case the controller could call the render method twice. 

For example here: https://theyvoteforyou.org.au/people/representatives/wentworth/malcolm_turnbull/divisions/2012-

This should render a 404 page due to the fact the date is bad formatted. However, because it's also a `Member` page it also renders the `Member` page as well. This PR fixed that making sure, it renders the 404 page avoiding to go further at the code.

As a second thought, I think it would be nice to have a different method and different route for the member's division page.

