### PR TITLE
Show a tantalising message if there's been no edits in the last week

### DIFF
--- a/app/views/home/history.html.haml
+++ b/app/views/home/history.html.haml
@@ -5,4 +5,8 @@
     .page-header.container
       %h1 All edits made in the last week
 
-= render partial: "layouts/history_list"
+- if @history.empty?
+  %p
+    None yet… but you’ll show up here when you help by #{link_to "summarising divisions", help_research_path} and by #{link_to "creating and maintaining policies", policies_path}.
+- else
+  = render partial: "layouts/history_list"


### PR DESCRIPTION
Before this change the recent edits page showed a blank page if nothing
had happened in the last week. It now tries to entice the viewer into
contributing by reminding them that they'll be shown on the history page
if they make a contribution. It also links off to pages to help them do
that.

![selection_001](https://cloud.githubusercontent.com/assets/48945/24987890/bb67110a-2045-11e7-8ff2-7e711fdcbaad.png)
