### PR TITLE
Updated definition of attendance in FAQ Fixes #1156

### DIFF
--- a/app/assets/stylesheets/policies/_policy-voter-comparision.scss
+++ b/app/assets/stylesheets/policies/_policy-voter-comparision.scss
@@ -130,3 +130,7 @@
 *:hover > .anchor {
   display: block;
 }
+
+.remove-padding {
+  padding: 0px 0px;
+}

--- a/app/views/help/faq/_attendance.md
+++ b/app/views/help/faq/_attendance.md
@@ -1,14 +1,9 @@
-"Attendance" figures record the politicians who vote in any given division.
+"Attendence" figure describes the amount of times a representative has attended the Chamber as a percentage.
+	
+Where 100% attendence means the representative has not missed a single parlimentary sitting.
 
-There are several reasons why a politician may have low attendance figures. For example, they may
-have abstained, have ministerial or other duties or they may be the speaker.
+There are several reasons why a politician may have low attendance figures. For example, they may have abstained, have ministerial or other duties or they may be the speaker.
 
-People that “[pair](http://www.aph.gov.au/About_Parliament/Senate/Powers_practice_n_procedures/odgers/chap1107)”
-are also shown as absent. Pairing is an informal arrangement between parties that allows a person
-that is absent to have their vote cancelled out by someone who was planning to vote the other way
-also agreeing to be absent for the vote.
+We have no way of telling the difference between someone that was not in parliament on the day, was busy with other duties in parliament and someone who actively abstained because this is not officially recorded anywhere. In future when this is recorded we will show it to you.
 
-We have no way of telling the difference between someone that was not in parliament on the day, was
-busy with other duties in parliament and someone who actively abstained (e.g. by [running out of the
-chamber as the division is called](https://www.youtube.com/watch?v=XBgfE3Qc7_g)) because this is not
-officially recorded anywhere. In future when this is recorded we will show it to you.
+See more [here](https://www.aph.gov.au/About_Parliament/House_of_Representatives/Powers_practice_and_procedure/Practice7/HTML/Chapter5/Attendance)

--- a/app/views/help/faq/_attendance.md
+++ b/app/views/help/faq/_attendance.md
@@ -1,4 +1,4 @@
-"Attendence" figure describes the amount of times a representative has attended the Chamber as a percentage.
+"Attendance" figure describes the amount of times a representative has attended the Chamber as a percentage.
 	
 Where 100% attendence means the representative has not missed a single parlimentary sitting.
 

--- a/app/views/policies/show_with_member.html.haml
+++ b/app/views/policies/show_with_member.html.haml
@@ -22,7 +22,7 @@
 
 = render "policies/draft_warning", policy: @policy
 
-%p.col-sm-7
+%p.col-sm-7.remove-padding
   How
   = link_to @member.name, @member
   voted compared to someone who believes that


### PR DESCRIPTION
Updated definition of attendance in FAQ.

Using the definition published on aph.gov.au [here](https://www.aph.gov.au/About_Parliament/House_of_Representatives/Powers_practice_and_procedure/Practice7/HTML/Chapter5/Attendance)

I removed both URL's in the previous version of the definition as both links led to a 404/content not found

I also kept part of the old definition which explains the reasons why a member could have low attendance
