### PR TITLE
Fixed alignment of top paragraph in members policies view.

### DIFF
--- a/app/assets/stylesheets/policies/_policy-voter-comparision.scss
+++ b/app/assets/stylesheets/policies/_policy-voter-comparision.scss
@@ -130,3 +130,7 @@
 *:hover > .anchor {
   display: block;
 }
+
+.remove-padding {
+  padding: 0px 0px;
+}

--- a/app/views/policies/show_with_member.html.haml
+++ b/app/views/policies/show_with_member.html.haml
@@ -22,7 +22,7 @@
 
 = render "policies/draft_warning", policy: @policy
 
-%p.col-sm-7
+%p.col-sm-7.remove-padding
   How
   = link_to @member.name, @member
   voted compared to someone who believes that

--- a/spec/fixtures/static_pages/people/representatives/griffith/kevin_rudd/policies/1.html
+++ b/spec/fixtures/static_pages/people/representatives/griffith/kevin_rudd/policies/1.html
@@ -94,7 +94,7 @@ Twitter
 </div>
 </div>
 
-<p class='col-sm-7'>
+<p class='col-sm-7 remove-padding'>
 How
 <a href="/people/representatives/griffith/kevin_rudd">Kevin Rudd</a>
 voted compared to someone who believes that

--- a/spec/fixtures/static_pages/people/representatives/warringah/tony_abbott/policies/1.html
+++ b/spec/fixtures/static_pages/people/representatives/warringah/tony_abbott/policies/1.html
@@ -94,7 +94,7 @@ Twitter
 </div>
 </div>
 
-<p class='col-sm-7'>
+<p class='col-sm-7 remove-padding'>
 How
 <a href="/people/representatives/warringah/tony_abbott">Tony Abbott</a>
 voted compared to someone who believes that

--- a/spec/fixtures/static_pages/people/senate/tasmania/christine_milne/policies/1.html
+++ b/spec/fixtures/static_pages/people/senate/tasmania/christine_milne/policies/1.html
@@ -94,7 +94,7 @@ Twitter
 </div>
 </div>
 
-<p class='col-sm-7'>
+<p class='col-sm-7 remove-padding'>
 How
 <a href="/people/senate/tasmania/christine_milne">Christine Milne</a>
 voted compared to someone who believes that


### PR DESCRIPTION
This PR fixes issue #1095 by adding a .remove-padding class to the `<p>` tag.

