### PR TITLE
Added Sort by Date Edited feature to policies index page

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -10,6 +10,8 @@ class PoliciesController < ApplicationController
     case @sort
     when "name"
       @policies = @policies.order(:name)
+    when "date"
+      @policies = @policies.order("updated_at DESC")
     else
       @policies = @policies.left_joins(:watches).group(:id).order("COUNT(watches.id) DESC")
       @sort = nil

--- a/app/views/policies/_policies_chooser.html.haml
+++ b/app/views/policies/_policies_chooser.html.haml
@@ -3,7 +3,7 @@
     %button.btn.btn-sm.btn-default.dropdown-toggle{type: "button", id: "dropdownMenu1", data: {toggle: "dropdown"}}
       - if @sort == "name"
         Sorted by Name
-      - elseif @sort == "date"
+      - elsif @sort == "date"
         Sorted by Date Edited
       - elsif @sort.nil?
         Sorted by Subscribers

--- a/app/views/policies/_policies_chooser.html.haml
+++ b/app/views/policies/_policies_chooser.html.haml
@@ -3,7 +3,7 @@
     %button.btn.btn-sm.btn-default.dropdown-toggle{type: "button", id: "dropdownMenu1", data: {toggle: "dropdown"}}
       - if @sort == "name"
         Sorted by Name
-      - if @sort == "date"
+      - elseif @sort == "date"
         Sorted by Date Edited
       - elsif @sort.nil?
         Sorted by Subscribers

--- a/app/views/policies/_policies_chooser.html.haml
+++ b/app/views/policies/_policies_chooser.html.haml
@@ -3,6 +3,8 @@
     %button.btn.btn-sm.btn-default.dropdown-toggle{type: "button", id: "dropdownMenu1", data: {toggle: "dropdown"}}
       - if @sort == "name"
         Sorted by Name
+      - if @sort == "date"
+        Sorted by Date Edited
       - elsif @sort.nil?
         Sorted by Subscribers
       %span.caret
@@ -12,3 +14,5 @@
         = link_to "Name", {sort: "name"}, title: "Sort by name", role: "menuitem", tabindex: "-1"
       %li{role: "presentation", class: "#{'disabled' if @sort.nil?}"}
         = link_to "Subscribers", {sort: nil}, title: "Sort by subscribers", role: "menuitem", tabindex: "-1"
+      %li{role: "presentation", class: "#{'disabled' if @sort == 'date'}"}
+        = link_to "Date Edited", {sort: "date"}, title: "Sort by date edited", role: "menuitem", tabindex: "-1"

--- a/spec/fixtures/static_pages/policies.html
+++ b/spec/fixtures/static_pages/policies.html
@@ -82,6 +82,9 @@ Sorted by Subscribers
 <li class='disabled' role='presentation'>
 <a title="Sort by subscribers" role="menuitem" tabindex="-1" href="/policies">Subscribers</a>
 </li>
+<li class='' role='presentation'>
+<a title="Sort by date edited" role="menuitem" tabindex="-1" href="/policies?sort=date">Date Edited</a>
+</li>
 </ul>
 </div>
 </div>


### PR DESCRIPTION
This PR allows for sorting policies on the policies index page by date edited.

This PR solves issue #1290. 

Note, in the schema the wording used is `updated_at`. I chose to use `date edited` in order to stay consistent with the the policies banner. 

Check this image:

![edited about](https://user-images.githubusercontent.com/86769131/146116324-58a0e14f-60d5-4de6-8e81-6d086d9a9cfd.png)
