### PR TITLE
Fixed code smell mentioned in previous PR conversation

### DIFF
--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -132,7 +132,7 @@ namespace :application do
 
       md = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
       broken_url_constant = 999
-      url_hash_table = Hash.new(0)
+      visited_urls = Hash.new(0)
       Division.find_each do |division|
         wiki_motion = division.wiki_motion
 
@@ -146,15 +146,15 @@ namespace :application do
             url = tag[:href]
 
             begin
-              if (url_hash_table[url]).zero?
-                url_hash_table[url] += 1
+              if (visited_urls[url]).zero?
+                visited_urls[url] += 1
                 uri = URI(url)
                 Net::HTTP.get(uri)
-              elsif url_hash_table[url] == broken_url_constant
+              elsif visited_urls[url] == broken_url_constant
                 broken_urls << url
               end
             rescue StandardError
-              url_hash_table[url] = broken_url_constant
+              visited_urls[url] = broken_url_constant
               broken_urls << url
             end
           end

--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -158,9 +158,11 @@ namespace :application do
               broken_urls << url
             end
           end
-          puts "There are broken links in the description for division #{division_url_simple(division)}"
-          broken_urls.each do |broken_url|
-            puts "\t#{broken_url}"
+          if broken_urls.length.positive?
+            puts "There are broken links in the description for division #{division_url_simple(division)}"
+            broken_urls.each do |broken_url|
+              puts "\t#{broken_url}"
+            end
           end
         end
       end

--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -131,7 +131,6 @@ namespace :application do
       include PathHelper
 
       md = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
-      broken_url_constant = 999
       visited_urls = Hash.new(0)
       broken_urls_table = Hash.new(0)
       Division.find_each do |division|

--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -133,6 +133,7 @@ namespace :application do
       md = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
       broken_url_constant = 999
       visited_urls = Hash.new(0)
+      broken_urls_table = Hash.new(0)
       Division.find_each do |division|
         wiki_motion = division.wiki_motion
 
@@ -150,11 +151,11 @@ namespace :application do
                 visited_urls[url] += 1
                 uri = URI(url)
                 Net::HTTP.get(uri)
-              elsif visited_urls[url] == broken_url_constant
+              elsif broken_urls_table[url].positive?
                 broken_urls << url
               end
             rescue StandardError
-              visited_urls[url] = broken_url_constant
+              broken_urls_table[url] += 1
               broken_urls << url
             end
           end


### PR DESCRIPTION
1. Refactored `url_hash_table` to `visited_url`.
2. `visited_url` now has 1 use only and that is to cache the visited urls.
3. `broken_urls_table` now stores the broken urls
4. Only prints when there are broken urls.
5. Constant removed since its no longer in use.