### PR TITLE
Screenshot rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,9 @@ gem "flipper-ui"
 # Used for checking whether URLs are valid in rake task
 gem "httparty"
 
+# Used for taking screenshots of the social media cards in rake tas
+gem "selenium-webdriver"
+
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     config (4.0.0)
@@ -500,6 +501,7 @@ GEM
     ruby_parser (3.18.1)
       sexp_processor (~> 4.16)
     rubyntlm (0.6.3)
+    rubyzip (2.3.2)
     safe_attributes (1.0.10)
       activerecord (>= 3.0.0)
     sanitize (6.0.0)
@@ -525,6 +527,10 @@ GEM
       activerecord (>= 4)
       activesupport (>= 4)
     selectize-rails (0.12.6)
+    selenium-webdriver (4.1.0)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.16.0)
     shellany (0.0.1)
     simple_form (5.1.0)
@@ -666,6 +672,7 @@ DEPENDENCIES
   sdoc
   searchkick
   seed_dump
+  selenium-webdriver
   simple_form
   simplecov
   sprockets

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,7 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 Rails.application.config.assets.precompile += %w( email.css )
+
+Rails.application.config.assets.configure do |env|
+  env.export_concurrent = false
+end

--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -168,4 +168,29 @@ namespace :application do
       end
     end
   end
+
+  namespace :generate do
+    desc "Screenshot and save urls given by their names."
+    task :capture_screenshots, %i[urls save_path width height] => :environment do |_t, args|
+      require "selenium-webdriver"
+      include PathHelper
+      include Rails.application.routes.url_helpers
+
+      options = Selenium::WebDriver::Chrome::Options.new
+      options.add_argument("--headless")
+      driver = Selenium::WebDriver.for :chrome, options: options
+
+      args[:urls].each do |url_and_name|
+        url, file_name = url_and_name
+        driver.get(url)
+        driver.manage.window.resize_to(args[:width], args[:height])
+        picture = driver.screenshot_as(:png)
+        File.open("#{args[:save_path]}/#{file_name}", "wb+") do |fh|
+          fh.write picture
+        end
+      end
+
+      driver.quit
+    end
+  end
 end

--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -192,5 +192,23 @@ namespace :application do
 
       driver.quit
     end
+
+    desc "Generate screenshots for social media sharing of how a member voted on a policy"
+    task member_policy_vote: :environment do
+      include PathHelper
+      include Rails.application.routes.url_helpers
+      urls_and_name = []
+
+      PolicyPersonDistance.find_each do |ppd|
+        temp = []
+        member = Person.find(ppd.person_id).latest_member
+        policy = Policy.find(ppd.policy_id)
+        temp << "http://#{ActionMailer::Base.default_url_options[:host]}#{member_policy_path_simple(member, policy)}?card=true&pp=disable"
+        temp << "#{member.id}_#{policy.id}.png"
+        urls_and_name << temp
+      end
+      save_path = Rails.root.join("app/assets/images/production_cards/member_policy_vote")
+      task("application:generate:capture_screenshots").invoke(urls_and_name, save_path, 600, 350)
+    end
   end
 end

--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -170,6 +170,11 @@ namespace :application do
   end
 
   namespace :generate do
+    desc "A task to capture all screenshots of the social media sharing cards"
+    task cards: :environment do
+      task("application:generate:member_policy_vote").invoke
+    end
+
     desc "Screenshot and save urls given by their names."
     task :capture_screenshots, %i[urls save_path width height] => :environment do |_t, args|
       require "selenium-webdriver"


### PR DESCRIPTION
Could now automatically take screenshots of all social media sharing cards. As described in https://github.com/openaustralia/publicwhip/issues/1338.

Once #1340 is done we can add `task("application:generate:cards").invoke` to the daily rake task