### PR TITLE
Scrollbar fix

### DIFF
--- a/app/assets/stylesheets/card/_card.scss
+++ b/app/assets/stylesheets/card/_card.scss
@@ -44,6 +44,6 @@
   font-size: 10px;
 }
 
-body::-webkit-scrollbar {
+.social_media_cards::-webkit-scrollbar {
   display: none;
 }

--- a/app/views/layouts/card_layout.html.haml
+++ b/app/views/layouts/card_layout.html.haml
@@ -17,5 +17,5 @@
 
     = csrf_meta_tag
     = display_meta_tags
-  %body{class: "#{body_class}"}
+  %body{class: "social_media_cards"}
     = yield 


### PR DESCRIPTION
Now brings back the scroll bar on all pages other than the card pages.

Scrolling is back on other pages.
![scroll_bar](https://user-images.githubusercontent.com/86769131/156053848-e48a4dc1-8fea-45b1-8b40-825ae4ef1296.gif)

Fixes #1360 