### PR TITLE
Headline search

### DIFF
--- a/app/assets/stylesheets/home/_front-page.scss
+++ b/app/assets/stylesheets/home/_front-page.scss
@@ -2,6 +2,8 @@
   background-color: $color-orange;
   padding-bottom: 45px;
   margin-bottom: 0;
+  padding-left: 15px;
+  padding-right: 15px;
 
   @media (min-width: $screen-xs-min) {
     padding-top: 45px;

--- a/app/models/member_distance.rb
+++ b/app/models/member_distance.rb
@@ -9,7 +9,7 @@ class MemberDistance < ApplicationRecord
     1 - distance_a
   end
 
-  def agreement_fraction_without_abstentions
+  def agreement_fraction_without_absences
     1 - distance_b
   end
 


### PR DESCRIPTION
Fixed Left alignment of central headline and search on mobile on the landing page. 
This solves issue #1330 