### PR TITLE
Fixed left alignment for headline and search on mobile

### DIFF
--- a/app/assets/stylesheets/home/_front-page.scss
+++ b/app/assets/stylesheets/home/_front-page.scss
@@ -2,6 +2,8 @@
   background-color: $color-orange;
   padding-bottom: 45px;
   margin-bottom: 0;
+  padding-left: 15px;
+  padding-right: 15px;
 
   @media (min-width: $screen-xs-min) {
     padding-top: 45px;


### PR DESCRIPTION
Fixed Left alignment of central headline and search on mobile on the landing page. 
This solves issue #1330 