### PR TITLE
Let the width and height be determined by the creator of the screenshotter

### DIFF
--- a/app/lib/card_screenshotter/utils.rb
+++ b/app/lib/card_screenshotter/utils.rb
@@ -2,13 +2,13 @@
 
 module CardScreenshotter
   class Utils
-    CARD_WIDTH = 600
-    CARD_HEIGHT = 350
     RESTART_BROWSER_AFTER_NUMBER_OF_REQUESTS = 50
 
     attr_reader :driver
 
-    def initialize
+    def initialize(card_width, card_height)
+      @card_width = card_width
+      @card_height = card_height
       open_headless_driver!
     end
 
@@ -23,7 +23,7 @@ module CardScreenshotter
       options = Selenium::WebDriver::Chrome::Options.new
       options.add_argument("--headless")
       @driver = Selenium::WebDriver.for :chrome, capabilities: [options]
-      driver.manage.window.resize_to(CARD_WIDTH, CARD_HEIGHT)
+      driver.manage.window.resize_to(@card_width, @card_height)
     end
 
     def close_driver!


### PR DESCRIPTION
These changes are made since not all cards are of the same size. Hence, let the caller determine the size they need upon initialising a new instance