### PR TITLE
Now lets members determine the screenshotters width and height

### DIFF
--- a/app/lib/card_screenshotter/members.rb
+++ b/app/lib/card_screenshotter/members.rb
@@ -5,9 +5,11 @@ module CardScreenshotter
     class << self
       include Rails.application.routes.url_helpers
       include PathHelper
+      CARD_WIDTH = 600
+      CARD_HEIGHT = 350
 
       def update_screenshots
-        screenshotter = CardScreenshotter::Utils.new
+        screenshotter = CardScreenshotter::Utils.new(CARD_WIDTH, CARD_HEIGHT)
         ppds = PolicyPersonDistance.all
         progress = ProgressBar.create(title: "Members screenshots", total: ppds.count, format: "%t: |%B| %E %a")
         ppds.find_each do |ppd|


### PR DESCRIPTION
Since not all cards are the same size. Member now has its own `CARD_WIDTH` and `CARD_HEIGHT` constants and are passed onto the screenshotted upon init

This PR can only be merged after https://github.com/openaustralia/publicwhip/pull/1373 is reviewed and merged. Changes in this PR depend on changes made in https://github.com/openaustralia/publicwhip/pull/1373.
