### PR TITLE
Member image screenshot

### DIFF
--- a/app/lib/card_screenshotter/members.rb
+++ b/app/lib/card_screenshotter/members.rb
@@ -33,8 +33,18 @@ module CardScreenshotter
         end
       end
 
-      def url(ppd)
-        person_policy_url_simple(ppd.person, ppd.policy, ActionMailer::Base.default_url_options.merge(card: true))
+
+      def url(object, options = {})
+        case options[:type]
+        when "ppd"
+          ppd = object
+          person_policy_url_simple(ppd.person, ppd.policy, ActionMailer::Base.default_url_options.merge(card: true))
+        when "member"
+          member = object
+          member_url(member.url_params.merge(ActionMailer::Base.default_url_options.merge(card: true)))
+        else
+          raise StandardError, "Invalid Options! Cannot generate URL"
+        end
       end
 
       def save_path(ppd)

--- a/app/lib/card_screenshotter/members.rb
+++ b/app/lib/card_screenshotter/members.rb
@@ -8,6 +8,11 @@ module CardScreenshotter
 
       def update_screenshots
         screenshotter = CardScreenshotter::Utils.new
+        update_policy_vote_screenshot(screenshotter)
+        update_member_screenshot(screenshotter)
+        screenshotter.close_driver!
+      end
+
       def update_policy_vote_screenshot(screenshotter)
         options = { type: "ppd" }
         ppds = PolicyPersonDistance.all

--- a/app/lib/card_screenshotter/members.rb
+++ b/app/lib/card_screenshotter/members.rb
@@ -8,13 +8,14 @@ module CardScreenshotter
 
       def update_screenshots
         screenshotter = CardScreenshotter::Utils.new
+      def update_policy_vote_screenshot(screenshotter)
+        options = { type: "ppd" }
         ppds = PolicyPersonDistance.all
-        progress = ProgressBar.create(title: "Members screenshots", total: ppds.count, format: "%t: |%B| %E %a")
+        progress = ProgressBar.create(title: "Members votes on policies screenshots", total: ppds.count, format: "%t: |%B| %E %a")
         ppds.find_each do |ppd|
-          update_screenshot(screenshotter, ppd)
+          update_screenshot(screenshotter, ppd, options)
           progress.increment
         end
-        screenshotter.close_driver!
       end
 
       def update_screenshot(screenshotter, ppd)

--- a/app/lib/card_screenshotter/members.rb
+++ b/app/lib/card_screenshotter/members.rb
@@ -18,8 +18,14 @@ module CardScreenshotter
         end
       end
 
-      def update_screenshot(screenshotter, ppd)
-        screenshotter.screenshot_and_save(url(ppd), save_path(ppd))
+      def update_member_screenshot(screenshotter)
+        options = { type: "member" }
+        members = Member.all
+        progress = ProgressBar.create(title: "Members page screenshots", total: members.count, format: "%t: |%B| %E %a")
+        members.each do |member|
+          update_screenshot(screenshotter, member, options)
+          progress.increment
+        end
       end
 
       def url(ppd)

--- a/app/lib/card_screenshotter/members.rb
+++ b/app/lib/card_screenshotter/members.rb
@@ -57,7 +57,6 @@ module CardScreenshotter
           "public/cards#{person_policy_path_simple(ppd.person, ppd.policy)}.png"
         when "member"
           member = object
-          puts "public/cards#{member_path_simple(member)}.png"
           "public/cards#{member_path_simple(member)}.png"
         else
           raise StandardError, "Invalid Options! Cannot generate save path"

--- a/app/lib/card_screenshotter/members.rb
+++ b/app/lib/card_screenshotter/members.rb
@@ -47,8 +47,18 @@ module CardScreenshotter
         end
       end
 
-      def save_path(ppd)
-        "public/cards#{person_policy_path_simple(ppd.person, ppd.policy)}.png"
+      def save_path(object, options = {})
+        case options[:type]
+        when "ppd"
+          ppd = object
+          "public/cards#{person_policy_path_simple(ppd.person, ppd.policy)}.png"
+        when "member"
+          member = object
+          puts "public/cards#{member_path_simple(member)}.png"
+          "public/cards#{member_path_simple(member)}.png"
+        else
+          raise StandardError, "Invalid Options! Cannot generate save path"
+        end
       end
     end
   end

--- a/app/lib/card_screenshotter/members.rb
+++ b/app/lib/card_screenshotter/members.rb
@@ -33,6 +33,9 @@ module CardScreenshotter
         end
       end
 
+      def update_screenshot(screenshotter, object, options = {})
+        screenshotter.screenshot_and_save(url(object, options), save_path(object, options))
+      end
 
       def url(object, options = {})
         case options[:type]


### PR DESCRIPTION
I updated the code such that it now screenshots both:
1. Cards for how a member voted on a policy
2. Cards for member pages

If we ever want to add any more card screenshots for members then we simple would have to add a new method to iterate over what we want to be screenshotted and update the `case` statement in both `url` and `save_path` to create different URL's and save paths