### PR TITLE
Remove for in front of policy name

### DIFF
--- a/app/views/policies/_page_header.html.haml
+++ b/app/views/policies/_page_header.html.haml
@@ -7,7 +7,9 @@
     = link_to "New policy", new_policy_path, class: "link-policy-new btn btn-primary btn-xs"
   %h1.col-md-9.col-lg-10.long-title
     = yield :title
-  .lead.policytext.col-md-12= capitalise_initial_character policy.description
+  .lead.policytext.col-md-12
+    Those for this policy agree that
+    = policy.description
 
   .header-secondary.col-sm-12
     .header-secondary-primary-block.subscribe-block

--- a/app/views/policies/_page_header.html.haml
+++ b/app/views/policies/_page_header.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, capitalise_initial_character(policy.name_with_for)
+- content_for :title, capitalise_initial_character(policy.name)
 - set_meta_tags description: "Find out how people in parliament stand on #{policy.name}."
 
 .page-header.row

--- a/app/views/policies/_policies_list.html.haml
+++ b/app/views/policies/_policies_list.html.haml
@@ -4,7 +4,7 @@
       = link_to policy, class: 'object-item panel-link row' do
         %article
           %h2.policy-title.object-heading.panel-link-title.col-md-7
-            = capitalise_initial_character(policy.name_with_for)
+            = capitalise_initial_character(policy.name)
 
           %p.policy-data.object-secondary
             %span

--- a/spec/features/policies_spec.rb
+++ b/spec/features/policies_spec.rb
@@ -27,7 +27,7 @@ describe "Policies", type: :feature do
     click_button "Make Policy"
     expect(page).to have_content "Successfully made new policy"
     expect(page).to have_content "The creation of quality policies on this site"
-    expect(page).to have_content "Quality contributions are the bedrock of community projects"
+    expect(page).to have_content "Those for this policy agree that quality contributions are the bedrock of community projects"
   end
 
   it "editing existing" do

--- a/spec/features/policies_spec.rb
+++ b/spec/features/policies_spec.rb
@@ -26,7 +26,7 @@ describe "Policies", type: :feature do
     end
     click_button "Make Policy"
     expect(page).to have_content "Successfully made new policy"
-    expect(page).to have_content "For the creation of quality policies on this site"
+    expect(page).to have_content "The creation of quality policies on this site"
     expect(page).to have_content "Quality contributions are the bedrock of community projects"
   end
 

--- a/spec/fixtures/static_pages/policies.html
+++ b/spec/fixtures/static_pages/policies.html
@@ -16,6 +16,7 @@ Policies
 <![endif]-->
 
 <meta name="description" content="A list of policies available on They Vote For You. Policies are a group of votes which, taken together, indicate a particular stance on an issue. You can research and create your own.">
+
 </head>
 <body class='policies'>
 <nav class='site-header navbar' role='navigation'>
@@ -92,7 +93,7 @@ Sorted by Subscribers
 <li>
 <a class="object-item panel-link row" href="/policies/1"><article>
 <h2 class='policy-title object-heading panel-link-title col-md-7'>
-For marriage equality
+Marriage equality
 </h2>
 <p class='policy-data object-secondary'>
 <span>
@@ -113,7 +114,7 @@ edited 1 day ago
 <li>
 <a class="object-item panel-link row" href="/policies/2"><article>
 <h2 class='policy-title object-heading panel-link-title col-md-7'>
-For offshore processing
+Offshore processing
 </h2>
 <p class='policy-data object-secondary'>
 <span>

--- a/spec/fixtures/static_pages/policies/1.html
+++ b/spec/fixtures/static_pages/policies/1.html
@@ -5,7 +5,7 @@
 <meta content='IE=edge' http-equiv='X-UA-Compatible'>
 <meta content='width=device-width, initial-scale=1' name='viewport'>
 <title>
-For marriage equality
+Marriage equality
 — They Vote For You
 </title>
 <link rel="stylesheet" media="screen" href="//code.cdn.mozilla.net/fonts/fira.css" />
@@ -72,7 +72,7 @@ by
 <a class="link-policy-new btn btn-primary btn-xs" href="/policies/new">New policy</a>
 </nav>
 <h1 class='col-md-9 col-lg-10 long-title'>
-For marriage equality
+Marriage equality
 </h1>
 <div class='lead policytext col-md-12'>Access to marriage should be equal</div>
 <div class='header-secondary col-sm-12'>

--- a/spec/fixtures/static_pages/policies/1.html
+++ b/spec/fixtures/static_pages/policies/1.html
@@ -74,7 +74,10 @@ by
 <h1 class='col-md-9 col-lg-10 long-title'>
 Marriage equality
 </h1>
-<div class='lead policytext col-md-12'>Access to marriage should be equal</div>
+<div class='lead policytext col-md-12'>
+Those for this policy agree that
+access to marriage should be equal
+</div>
 <div class='header-secondary col-sm-12'>
 <div class='header-secondary-primary-block subscribe-block'>
 <form class="subscribe-button-form subscribe-button-form-subscribe" method="post" action="/policies/1/watch"><button class="btn btn-link fi-mail" type="submit">Subscribe

--- a/spec/fixtures/static_pages/policies/2.html
+++ b/spec/fixtures/static_pages/policies/2.html
@@ -5,7 +5,7 @@
 <meta content='IE=edge' http-equiv='X-UA-Compatible'>
 <meta content='width=device-width, initial-scale=1' name='viewport'>
 <title>
-For offshore processing
+Offshore processing
 — They Vote For You
 </title>
 <link rel="stylesheet" media="screen" href="//code.cdn.mozilla.net/fonts/fira.css" />
@@ -72,7 +72,7 @@ by
 <a class="link-policy-new btn btn-primary btn-xs" href="/policies/new">New policy</a>
 </nav>
 <h1 class='col-md-9 col-lg-10 long-title'>
-For offshore processing
+Offshore processing
 </h1>
 <div class='lead policytext col-md-12'>Refugees arrving by boat should be processed offshore</div>
 <div class='header-secondary col-sm-12'>

--- a/spec/fixtures/static_pages/policies/2.html
+++ b/spec/fixtures/static_pages/policies/2.html
@@ -74,7 +74,10 @@ by
 <h1 class='col-md-9 col-lg-10 long-title'>
 Offshore processing
 </h1>
-<div class='lead policytext col-md-12'>Refugees arrving by boat should be processed offshore</div>
+<div class='lead policytext col-md-12'>
+Those for this policy agree that
+refugees arrving by boat should be processed offshore
+</div>
 <div class='header-secondary col-sm-12'>
 <div class='header-secondary-primary-block subscribe-block'>
 <form class="subscribe-button-form subscribe-button-form-subscribe" method="post" action="/policies/2/watch"><button class="btn btn-link fi-mail" type="submit">Subscribe


### PR DESCRIPTION
Fixes #1348 

Also updates wording of description on policy detail page to make it obvious that the policy description is for those that agree with the policy