### PR TITLE
Changed `DOMContentLoaded` to `load` in all eventlisteners for all social media cards

### DIFF
--- a/app/views/card/member_card.html.haml
+++ b/app/views/card/member_card.html.haml
@@ -16,7 +16,7 @@
       = remove_slash(get_hostname(root_url) + member_path_simple(@member)) 
 
 :javascript
-  window.addEventListener('DOMContentLoaded', (event) => {
+  window.addEventListener('load', (event) => {
     fitin = document.querySelector('.fitin');
     fitin_inner = document.querySelector('div .socialmedia-card-heading-text');
 

--- a/app/views/card/member_category_card.html.haml
+++ b/app/views/card/member_category_card.html.haml
@@ -27,7 +27,7 @@
       = remove_slash(get_hostname(root_url) + member_path_simple(@member))
 
 :javascript
-  window.addEventListener('DOMContentLoaded', (event) => {
+  window.addEventListener('load', (event) => {
     fitin = document.querySelector('.fitin2');
     fitin_inner = document.querySelector('div .socialmedia-card-heading-text');
 

--- a/app/views/card/policy_card.html.haml
+++ b/app/views/card/policy_card.html.haml
@@ -23,7 +23,7 @@
       = remove_slash(get_hostname(root_url)) + policy_path(@policy)
 
 :javascript
-  window.addEventListener('DOMContentLoaded', (event) => {
+  window.addEventListener('load', (event) => {
     fitin = document.querySelector('.fitin2');
     fitin_inner = document.querySelector('div .socialmedia-card-heading-text');
 

--- a/app/views/card/policy_with_member_card.html.haml
+++ b/app/views/card/policy_with_member_card.html.haml
@@ -15,7 +15,7 @@
       = remove_slash(get_hostname(root_url) + member_policy_path_simple(@member, @policy))
 
 :javascript
-  window.addEventListener('DOMContentLoaded', (event) => {
+  window.addEventListener('load', (event) => {
     fitin = document.querySelector('.fitin');
     fitin_inner = document.querySelector('div .socialmedia-card-heading-text');
 


### PR DESCRIPTION
Fixes issue #1388

Changes all event listeners to fire off on `load` rather than on `DOMContentLoaded`