### PR TITLE
Image meta tag link to card

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -52,6 +52,7 @@ class MembersController < ApplicationController
   def friends; end
 
   def show
+    @cardtype = params[:type] # needs to be placed here otherwise it will not work (when placed within the else block)
     # If this isn't a social sharing card then just use the default view
     return if params[:card].nil?
 

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -26,7 +26,7 @@ class PoliciesController < ApplicationController
     @policy = Policy.find(params[:id])
     @sort = params[:sort]
     @categories = PolicyPersonDistance.all_categories(reverse: (@sort == "against"))
-
+    @cardtype = params[:type]
     return if params[:card].nil?
 
     if params[:category]

--- a/app/helpers/path_helper.rb
+++ b/app/helpers/path_helper.rb
@@ -29,12 +29,22 @@ module PathHelper
     "#{root_url}cards#{person_policy_path_simple(person, policy)}.png"
   end
 
-  def card_member_url(member)
-    "#{root_url}cards#{member_path_simple(member)}.png"
+  def card_member_url(member, cardtype)
+    case cardtype
+    when nil
+      "#{root_url}cards#{member_path_simple(member)}.png"
+    else
+      "#{root_url}cards#{member_path_simple(member)}/categories/#{cardtype}.png"
+    end
   end
 
-  def card_policy_url(policy)
-    "#{root_url}cards#{policy_path(policy)}.png"
+  def card_policy_url(policy, cardtype)
+    case cardtype
+    when nil
+      "#{root_url}cards#{policy_path(policy)}.png"
+    else
+      "#{root_url}cards#{policy_path(policy)}/categories/#{cardtype}.png"
+    end
   end
 
   def person_policy_url_simple(person, policy, options = {})

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -7,7 +7,7 @@
     type: "website",
     url: request.original_url,
     image: {
-      _: card_member_url(@member),
+      _: card_member_url(@member, @cardtype),
       alt: "Find out how #{@member.name} votes on issues that matter to you",
       width: CardScreenshotter::Utils::CARD_WIDTH,
       height: CardScreenshotter::Utils::CARD_HEIGHT

--- a/app/views/policies/_page_header.html.haml
+++ b/app/views/policies/_page_header.html.haml
@@ -7,7 +7,7 @@
     type: "website",
     url: request.original_url,
     image: {
-      _: card_policy_url(policy),
+      _: card_policy_url(policy, @cardtype),
       alt: "See How They Vote On #{capitalise_initial_character(policy.name)}",
       width: CardScreenshotter::Utils::CARD_WIDTH,
       height: CardScreenshotter::Utils::CARD_HEIGHT


### PR DESCRIPTION
This PR adds code which sets the image meta tag to the relevant card when given a `type` query param.