### PR TITLE
Add rake task to re-attach correct members to a small number of votes

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -33,6 +33,7 @@ class Policy < ApplicationRecord
     divisions.unedited.count
   end
 
+  # Note that this includes changes to policy record and policy_division records
   def most_recent_version
     PaperTrail::Version.order(created_at: :desc).find_by(policy_id: id)
   end


### PR DESCRIPTION
This fixes #1478 by creating a new rake task that looks for votes where old members are attached instead of ones that could have voted in that vote.

Still TODO is run this automatically periodically. 