### PR TITLE
Update CODEOWNERS to include code-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # This file is used to define code owners for this repository.
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @openaustralia/staff-devs
+* @openaustralia/code-reviewers


### PR DESCRIPTION
This pull request updates the code ownership assignment in the `.github/CODEOWNERS` file to reflect the current responsible team.

- Changed the default code owner from `@openaustralia/staff-devs` to `@openaustralia/code-reviewers` for the repository.