### PR TITLE
Add support for ed25519 keys for deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,10 +128,12 @@ group :development do
   # Add ?pp=flamegraph to the end of the url in development
   gem "stackprof"
 
+  gem "bcrypt_pbkdf", "~> 1.1"
   gem "capistrano", require: false
   gem "capistrano-rails", require: false
   gem "capistrano-rvm"
   gem "capistrano-maintenance", require: false
+  gem "ed25519", "~> 1.3"
 
   gem "mina"
   gem "mina-multistage", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       execjs (~> 2)
     base64 (0.3.0)
     bcrypt (3.1.22)
+    bcrypt_pbkdf (1.1.2)
     benchmark (0.5.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
@@ -164,6 +165,7 @@ GEM
     docile (1.4.1)
     domain_name (0.6.20240107)
     drb (2.2.3)
+    ed25519 (1.4.0)
     elasticsearch (7.17.11)
       elasticsearch-api (= 7.17.11)
       elasticsearch-transport (= 7.17.11)
@@ -659,6 +661,7 @@ DEPENDENCIES
   administrate
   attribute-defaults
   autoprefixer-rails
+  bcrypt_pbkdf (~> 1.1)
   better_errors
   binding_of_caller
   bootsnap
@@ -675,6 +678,7 @@ DEPENDENCIES
   delayed_job_active_record
   devise
   diffy
+  ed25519 (~> 1.3)
   elasticsearch (~> 7)
   email_spec
   factory_bot_rails


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/theyvoteforyou/issues/1613
* https://github.com/openaustralia/theyvoteforyou/issues/1612

## What does this do?

Adds required gems to Support ed25519 ssh keys for deployment

## Why was this needed?

Error as listed on issue

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
