### PR TITLE
Do not require capistrano gems unless actually deploying

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,8 +136,8 @@ group :development do
   gem "bcrypt_pbkdf", "~> 1.1"
   gem "capistrano", require: false
   gem "capistrano-rails", require: false
-  gem "capistrano-rvm"
-  gem "capistrano-tagging3", "~> 2.0"
+  gem "capistrano-rvm", require: false
+  gem "capistrano-tagging3", "~> 2.0", require: false
   gem "capistrano-maintenance", require: false
   gem "ed25519", "~> 1.3"
 


### PR DESCRIPTION
## Relevant issue(s)

Hotfix to:
* https://github.com/openaustralia/theyvoteforyou/pull/1616

## What does this do?

Fixes:
```
$ bundle exec rake
rake aborted!
Bundler::GemRequireError: There was an error while trying to load the gem 'capistrano-tagging3'. (Bundler::GemRequireError)
Gem Load Error is: Don't know how to build task 'deploy:cleanup' (See the list of available tasks with `rake --tasks`)
```

## Why was this needed?

Previous PR broke rake and we don't have a github action to run tests. Added issue to rectify that as well:
* https://github.com/openaustralia/theyvoteforyou/issues/1625

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
