### PR TITLE
Add arm64-darwin support and update RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -457,9 +457,11 @@ Style/YAMLFileRead: # new in 1.53
 
 Capybara/ClickLinkOrButtonStyle: # new in 2.19
   Enabled: true
-Capybara/MatchStyle: # new in 2.17
+Capybara/AssertStyle: # split from Capybara/MatchStyle in 2.23
   Enabled: true
-Capybara/NegationMatcher: # new in 2.14
+Capybara/RSpec/MatchStyle: # split from Capybara/MatchStyle in 2.23
+  Enabled: true
+Capybara/RSpec/NegationMatcher: # moved from Capybara/NegationMatcher in 2.23
   Enabled: true
 Capybara/RedundantWithinFind: # new in 2.20
   Enabled: true
@@ -467,7 +469,7 @@ Capybara/SpecificActions: # new in 2.14
   Enabled: true
 Capybara/SpecificFinders: # new in 2.13
   Enabled: true
-Capybara/SpecificMatcher: # new in 2.12
+Capybara/RSpec/SpecificMatcher: # moved from Capybara/SpecificMatcher in 2.23
   Enabled: true
 Capybara/RSpec/HaveSelector: # new in 2.19
   Enabled: true
@@ -564,5 +566,5 @@ RSpec/IncludeExamples: # new in 3.6
   Enabled: true
 Capybara/FindAllFirst: # new in 2.22
   Enabled: true
-Capybara/NegationMatcherAfterVisit: # new in 2.22
+Capybara/RSpec/NegationMatcherAfterVisit: # moved from Capybara/NegationMatcherAfterVisit in 2.23
   Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,7 @@ GEM
     faraday-typhoeus (1.1.0)
       faraday (~> 2.0)
       typhoeus (~> 1.4)
+    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     flipper (1.4.2)
@@ -303,6 +304,7 @@ GEM
       addressable (~> 2.8)
       childprocess (~> 5.0)
       logger (~> 1.6)
+    libv8-node (18.19.0.0-arm64-darwin)
     libv8-node (18.19.0.0-x86_64-darwin)
     libv8-node (18.19.0.0-x86_64-linux)
     lint_roller (1.1.0)
@@ -380,6 +382,8 @@ GEM
     net-ssh (7.3.0)
     nio4r (2.7.4)
     nkf (0.2.0)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
@@ -652,6 +656,7 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
+  arm64-darwin-25
   x86_64-darwin-20
   x86_64-linux
 


### PR DESCRIPTION
## Relevant issue(s)
- N/A

## What does this do?
1. Modifies RuboCop configuration to align with Capybara style changes introduced in version 2.23.
2. Adds support for the arm64-darwin platform and updates the Gemfile.lock to include necessary dependencies. 

## Why was this needed?
This change ensures adherence to the latest coding standards for Capybara, improving code quality and maintainability.

It also stops the CI from having a whinge

## Implementation/Deploy Steps (Optional)
1. Ensure that this PR passes CI
2. perform a dependabot rebase on the other PRs

## Notes to reviewer (Optional)

