### PR TITLE
Doc/manual security check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -457,9 +457,9 @@ Style/YAMLFileRead: # new in 1.53
 
 Capybara/ClickLinkOrButtonStyle: # new in 2.19
   Enabled: true
-Capybara/MatchStyle: # new in 2.17
+Capybara/Rspec/MatchStyle: # new in 2.17
   Enabled: true
-Capybara/NegationMatcher: # new in 2.14
+Capybara/Rspec/NegationMatcher: # new in 2.14
   Enabled: true
 Capybara/RedundantWithinFind: # new in 2.20
   Enabled: true
@@ -467,7 +467,7 @@ Capybara/SpecificActions: # new in 2.14
   Enabled: true
 Capybara/SpecificFinders: # new in 2.13
   Enabled: true
-Capybara/SpecificMatcher: # new in 2.12
+Capybara/Rspec/SpecificMatcher: # new in 2.12
   Enabled: true
 Capybara/RSpec/HaveSelector: # new in 2.19
   Enabled: true
@@ -564,5 +564,5 @@ RSpec/IncludeExamples: # new in 3.6
   Enabled: true
 Capybara/FindAllFirst: # new in 2.22
   Enabled: true
-Capybara/NegationMatcherAfterVisit: # new in 2.22
+Capybara/Rspec/NegationMatcherAfterVisit: # new in 2.22
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -145,12 +145,14 @@ group :development do
   gem "mina-multistage", require: false
   gem "brakeman", require: false
 
+  gem "bundle-audit", require: false
   gem "rubocop", require: false
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
   gem "rubocop-rspec_rails", require: false
   gem "rubocop-capybara", require: false
   gem "rubocop-factory_bot", require: false
+  gem "ruby_audit", require: false
 
   # Helps upgrade a whole bunch of gems at once
   gem "bummr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,11 @@ GEM
     bummr (1.1.0)
       rainbow
       thor
+    bundle-audit (0.2.0)
+      bundler-audit
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     capistrano (3.19.2)
       airbrussh (>= 1.0.0)
       i18n
@@ -551,6 +556,8 @@ GEM
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
+    ruby_audit (3.1.0)
+      bundler-audit (~> 0.9.0)
     ruby_parser (3.21.1)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -667,6 +674,7 @@ DEPENDENCIES
   bootstrap-select-rails
   brakeman
   bummr
+  bundle-audit
   capistrano
   capistrano-maintenance
   capistrano-rails
@@ -732,6 +740,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-rspec_rails
   ruby-progressbar
+  ruby_audit
   ruby_parser
   sass-rails
   sdoc

--- a/README.md
+++ b/README.md
@@ -224,6 +224,18 @@ The names of the features added in the admin panel need to match those in the co
 
 To enable a feature for a particular user: Go to the feature on the flipper admin panel. Then click the button "Add an actor". Then add the `flipper_id` which for a user will be of the form `User;<user id>`. So for example it could be `User;3`.
 
+## To run style and coding checks
+
+    bundle exec rubocop
+
+## To check for security updates
+
+Either check [Dependabot alerts](https://github.com/openaustralia/theyvoteforyou/security/dependabot) 
+for the main branch, taking note of when the last check was run, **or** run manually on current branch:
+
+    bundle exec ruby-audit
+    bundle exec bundle-audit
+
 ## Other Credits
 
 This project uses some icons from the noun project under creative commons licenses:


### PR DESCRIPTION
## Description

Document manual security check

## Motivation and Context
Dependabot doesn't check ruby versions and it differs from how bundle checks related gems

This is in preparation of performing security updates much faster than individual merge of dependabot PRs when there are a number of them.

## How Has This Been Tested?
Ran the commands as documented (only applicable to local dev system)
on Ubuntu 24.04.4 LTS x86_64 with ruby installed by mise, mysql 8.0, redis 5:7.0

Created as a draft PR, waited for Github checks to run and checked they passed!

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.